### PR TITLE
feat: add CLI argument parsing and command output

### DIFF
--- a/dev/src/lib/core/cli/args.ts
+++ b/dev/src/lib/core/cli/args.ts
@@ -1,0 +1,32 @@
+import type { ParseResult } from './types.ts';
+
+const COMMANDS = new Set(['doctor', 'curate', 'spawn'] as const);
+const HELP_FLAGS = new Set(['--help', '-h'] as const);
+
+export function parseArgs(argv: readonly string[]): ParseResult {
+  if (argv.length === 0) {
+    return { ok: false, error: { kind: 'usage-error', message: 'missing command', exitCode: 2 } };
+  }
+
+  const first = argv[0];
+
+  // Safe: .has() returns false for non-matching values; TS Set.has() requires element type
+  if (HELP_FLAGS.has(first as '--help' | '-h')) {
+    return { ok: true, command: { kind: 'help' } };
+  }
+
+  if (first === '--version') {
+    return { ok: true, command: { kind: 'version' } };
+  }
+
+  // Safe: .has() returns false for non-matching values; TS Set.has() requires element type
+  if (COMMANDS.has(first as 'doctor' | 'curate' | 'spawn')) {
+    if (argv.length > 1) {
+      return { ok: false, error: { kind: 'usage-error', message: `unexpected arguments: ${argv.slice(1).join(' ')}`, exitCode: 2 } };
+    }
+    // Safe: guarded by COMMANDS.has() check above
+    return { ok: true, command: { kind: first as 'doctor' | 'curate' | 'spawn' } };
+  }
+
+  return { ok: false, error: { kind: 'usage-error', message: `unknown command: ${first}`, exitCode: 2 } };
+}

--- a/dev/src/lib/core/cli/output.ts
+++ b/dev/src/lib/core/cli/output.ts
@@ -1,0 +1,20 @@
+import { VERSION, COPYRIGHT_YEAR, AUTHOR } from '../../shared/constants.ts';
+
+export function versionText(): string {
+  return `ai4X, v${VERSION}, © ${COPYRIGHT_YEAR} ${AUTHOR}`;
+}
+
+export function usageText(): string {
+  return [
+    'Usage: ai4x <command> [options]',
+    '',
+    'Commands:',
+    '  doctor    Run diagnostics',
+    '  curate    Curate agent definitions',
+    '  spawn     Spawn agent for target client',
+    '',
+    'Options:',
+    '  --help, -h     Show this help',
+    '  --version      Show version',
+  ].join('\n');
+}

--- a/dev/src/lib/shared/constants.ts
+++ b/dev/src/lib/shared/constants.ts
@@ -1,0 +1,6 @@
+import pkg from '../../../package.json' with { type: 'json' };
+
+export const VERSION: string = pkg.version;
+export const COPYRIGHT_YEAR = "2026";
+export const APP_NAME = "ai4X";
+export const AUTHOR = "nemron";

--- a/dev/src/lib/shared/log.ts
+++ b/dev/src/lib/shared/log.ts
@@ -1,9 +1,6 @@
-export type LogLevel = "info" | "warn" | "error";
+import { APP_NAME } from './constants.ts';
 
-export const VERSION = "0.1.0";
-export const COPYRIGHT_YEAR = "2026";
-export const APP_NAME = "ai4X";
-export const AUTHOR = "nemron";
+export type LogLevel = "info" | "warn" | "error";
 
 export function logLine(level: LogLevel, message: string): string {
   return `[${APP_NAME}|${level}] ${message}`;

--- a/dev/tsconfig.json
+++ b/dev/tsconfig.json
@@ -9,6 +9,7 @@
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "esModuleInterop": true,
+    "resolveJsonModule": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
     "declaration": false,

--- a/dev/tst/lib/core/cli/args.test.ts
+++ b/dev/tst/lib/core/cli/args.test.ts
@@ -1,0 +1,110 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import { parseArgs } from "../../../../src/lib/core/cli/args.ts";
+
+describe("parseArgs", () => {
+  describe("valid commands", () => {
+    it("recognizes 'doctor' as a valid command", () => {
+      const result = parseArgs(["doctor"]);
+      assert.deepStrictEqual(result, { ok: true, command: { kind: "doctor" } });
+    });
+
+    it("recognizes 'curate' as a valid command", () => {
+      const result = parseArgs(["curate"]);
+      assert.deepStrictEqual(result, { ok: true, command: { kind: "curate" } });
+    });
+
+    it("recognizes 'spawn' as a valid command", () => {
+      const result = parseArgs(["spawn"]);
+      assert.deepStrictEqual(result, { ok: true, command: { kind: "spawn" } });
+    });
+  });
+
+  describe("global flags", () => {
+    it("returns help command for --help", () => {
+      const result = parseArgs(["--help"]);
+      assert.deepStrictEqual(result, { ok: true, command: { kind: "help" } });
+    });
+
+    it("returns help command for -h", () => {
+      const result = parseArgs(["-h"]);
+      assert.deepStrictEqual(result, { ok: true, command: { kind: "help" } });
+    });
+
+    it("returns version command for --version", () => {
+      const result = parseArgs(["--version"]);
+      assert.deepStrictEqual(result, { ok: true, command: { kind: "version" } });
+    });
+
+    it("--help takes priority over trailing command", () => {
+      const result = parseArgs(["--help", "doctor"]);
+      assert.deepStrictEqual(result, { ok: true, command: { kind: "help" } });
+    });
+  });
+
+  describe("error cases", () => {
+    it("returns usage error for empty argv", () => {
+      const result = parseArgs([]);
+      assert.deepStrictEqual(result, {
+        ok: false,
+        error: { kind: "usage-error", message: "missing command", exitCode: 2 },
+      });
+    });
+
+    it("returns usage error for unknown command", () => {
+      const result = parseArgs(["frobnicate"]);
+      assert.deepStrictEqual(result, {
+        ok: false,
+        error: { kind: "usage-error", message: "unknown command: frobnicate", exitCode: 2 },
+      });
+    });
+
+    it("returns usage error for unknown flag", () => {
+      const result = parseArgs(["--unknown"]);
+      assert.deepStrictEqual(result, {
+        ok: false,
+        error: { kind: "usage-error", message: "unknown command: --unknown", exitCode: 2 },
+      });
+    });
+
+    it("returns usage error when command has trailing arguments", () => {
+      const result = parseArgs(["doctor", "extra"]);
+      assert.deepStrictEqual(result, {
+        ok: false,
+        error: { kind: "usage-error", message: "unexpected arguments: extra", exitCode: 2 },
+      });
+    });
+  });
+
+  describe("edge cases", () => {
+    it("treats --help after a command as unexpected argument, not a flag", () => {
+      const result = parseArgs(["doctor", "--help"]);
+      assert.deepStrictEqual(result, {
+        ok: false,
+        error: { kind: "usage-error", message: "unexpected arguments: --help", exitCode: 2 },
+      });
+    });
+
+    it("--version ignores trailing arguments", () => {
+      const result = parseArgs(["--version", "doctor"]);
+      assert.deepStrictEqual(result, { ok: true, command: { kind: "version" } });
+    });
+
+    it("all error results use exitCode 2", () => {
+      const errorInputs: readonly string[][] = [
+        [],
+        ["frobnicate"],
+        ["doctor", "extra"],
+        ["--unknown"],
+      ];
+      for (const argv of errorInputs) {
+        const result = parseArgs(argv);
+        assert.equal(result.ok, false);
+        if (!result.ok) {
+          assert.equal(result.error.exitCode, 2, `exitCode for argv=${JSON.stringify(argv)}`);
+        }
+      }
+    });
+  });
+});

--- a/dev/tst/lib/core/cli/output.test.ts
+++ b/dev/tst/lib/core/cli/output.test.ts
@@ -1,0 +1,46 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import { versionText, usageText } from "../../../../src/lib/core/cli/output.ts";
+import { VERSION, COPYRIGHT_YEAR, AUTHOR } from "../../../../src/lib/shared/constants.ts";
+
+describe("versionText", () => {
+  it("returns string matching expected format", () => {
+    assert.equal(versionText(), `ai4X, v${VERSION}, © ${COPYRIGHT_YEAR} ${AUTHOR}`);
+  });
+
+  it("contains VERSION from constants", () => {
+    assert.ok(versionText().includes(VERSION), "must contain VERSION");
+  });
+
+  it("contains brand name 'ai4X' (exact casing)", () => {
+    assert.ok(versionText().includes("ai4X"), "must contain 'ai4X'");
+  });
+});
+
+describe("usageText", () => {
+  it("starts with 'Usage: ai4x' (binary name lowercase)", () => {
+    assert.ok(usageText().startsWith("Usage: ai4x"), "must start with 'Usage: ai4x'");
+  });
+
+  it("contains all 3 commands: doctor, curate, spawn", () => {
+    const text = usageText();
+    assert.ok(text.includes("doctor"), "must mention doctor");
+    assert.ok(text.includes("curate"), "must mention curate");
+    assert.ok(text.includes("spawn"), "must mention spawn");
+  });
+
+  it("contains --help and --version options", () => {
+    const text = usageText();
+    assert.ok(text.includes("--help"), "must mention --help");
+    assert.ok(text.includes("--version"), "must mention --version");
+  });
+
+  it("contains -h alias", () => {
+    assert.ok(usageText().includes("-h"), "must mention -h alias");
+  });
+
+  it("is multi-line", () => {
+    assert.ok(usageText().includes("\n"), "must contain newlines");
+  });
+});

--- a/dev/tst/lib/shared/constants.test.ts
+++ b/dev/tst/lib/shared/constants.test.ts
@@ -1,0 +1,29 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import pkg from "../../../package.json" with { type: "json" };
+import {
+  VERSION,
+  APP_NAME,
+  COPYRIGHT_YEAR,
+  AUTHOR,
+} from "../../../src/lib/shared/constants.ts";
+
+describe("shared constants", () => {
+  it("VERSION matches package.json version", () => {
+    assert.equal(VERSION, pkg.version);
+  });
+
+  it("APP_NAME is ai4X", () => {
+    assert.equal(APP_NAME, "ai4X");
+  });
+
+  it("COPYRIGHT_YEAR is a non-empty string", () => {
+    assert.equal(typeof COPYRIGHT_YEAR, "string");
+    assert.ok(COPYRIGHT_YEAR.length > 0, "COPYRIGHT_YEAR must not be empty");
+  });
+
+  it("AUTHOR is nemron", () => {
+    assert.equal(AUTHOR, "nemron");
+  });
+});

--- a/dev/tst/lib/shared/log.test.ts
+++ b/dev/tst/lib/shared/log.test.ts
@@ -3,10 +3,6 @@ import assert from "node:assert/strict";
 
 import {
   logLine,
-  VERSION,
-  APP_NAME,
-  COPYRIGHT_YEAR,
-  AUTHOR,
 } from "../../../src/lib/shared/log.ts";
 
 describe("logLine formatting", () => {
@@ -24,24 +20,5 @@ describe("logLine formatting", () => {
 
   it("accepts an empty message without validation", () => {
     assert.equal(logLine("info", ""), "[ai4X|info] ");
-  });
-});
-
-describe("shared constants", () => {
-  it("VERSION matches package.json version", () => {
-    assert.equal(VERSION, "0.1.0");
-  });
-
-  it("APP_NAME is ai4X", () => {
-    assert.equal(APP_NAME, "ai4X");
-  });
-
-  it("COPYRIGHT_YEAR is a non-empty string", () => {
-    assert.equal(typeof COPYRIGHT_YEAR, "string");
-    assert.ok(COPYRIGHT_YEAR.length > 0, "COPYRIGHT_YEAR must not be empty");
-  });
-
-  it("AUTHOR is nemron", () => {
-    assert.equal(AUTHOR, "nemron");
   });
 });


### PR DESCRIPTION
## Story #4: CLI Argument Parsing

### Changes
- **`parseArgs()`** — pure function routing CLI arguments to discriminated union commands
- **`versionText()`** / **`usageText()`** — pure output text generators
- **`constants.ts`** — extracted shared constants; VERSION from `package.json` (single source of truth)
- **`tsconfig.json`** — enabled `resolveJsonModule`
- **Migrated** constant tests from `log.test.ts` to `constants.test.ts`

### Test Evidence
- 38 tests total (22 new), 0 failures
- Typecheck: 0 errors
- Behavior matrix fully covered (12 parseArgs scenarios + output + constants)

### Review Findings Resolved
- CA-01: Exit code policy (all errors → exitCode 2) ✓
- CA-02: VERSION via JSON import ✓
- CA-03: Edge cases (--unknown, doctor --help, --help doctor) ✓
- CA-04: usageText uses lowercase binary name ✓
- CB-01: Inline justification for `as` assertions ✓
- CB-02: Import ordering in log.ts ✓
- CB-03: --version trailing args test ✓

Closes #4