### PR TITLE
feat: add CLI entry point and integration tests

### DIFF
--- a/adm/gdl/dev/contracts/engineering-quality.md
+++ b/adm/gdl/dev/contracts/engineering-quality.md
@@ -49,6 +49,7 @@ Error states and optional values must be explicit in domain contracts.
 - Every recoverable failure path must be represented in the contract.
 - Error channels must preserve actionable context for callers.
 - Avoid ambiguous sentinel values to represent failure.
+- Prefer discriminated error variants with typed `kind` discriminators over generic error records with message strings. Dispatch on error kinds must use exhaustive pattern matching, not string comparison.
 
 ## Immutability by Default (MUST)
 

--- a/adm/gdl/dev/contracts/typescript-quality.md
+++ b/adm/gdl/dev/contracts/typescript-quality.md
@@ -24,6 +24,7 @@ Apply this contract to all TypeScript implementation work in `dev/src` and `dev/
 - `any` is prohibited except at explicit system boundaries with an inline comment stating why.
 - Type assertions (`as T`) require an inline justification when the assertion is non-trivial.
 - Prefer discriminated unions over loose type unions for domain variant modeling.
+- Use literal types for exit codes and error discriminators. Dispatch on `kind` fields, never on string content of message fields.
 - Do not use optional chaining as a substitute for explicit failure modeling at domain contracts.
 
 ## Module Structure (MUST)

--- a/dev/package.json
+++ b/dev/package.json
@@ -5,11 +5,11 @@
   "type": "module",
   "private": true,
   "engines": {
-    "node": ">=22.0.0"
+    "node": ">=23.6.0"
   },
   "scripts": {
     "typecheck": "tsc --noEmit",
-    "test": "node --test --experimental-strip-types tst/**/*.test.ts"
+    "test": "node --test tst/**/*.test.ts"
   },
   "devDependencies": {
     "@types/node": "^25.6.0",

--- a/dev/src/app/ai4x.ts
+++ b/dev/src/app/ai4x.ts
@@ -1,0 +1,34 @@
+import { parseArgs } from '../lib/core/cli/args.ts';
+import { usageText, versionText, errorText } from '../lib/core/cli/output.ts';
+import { logLine } from '../lib/shared/log.ts';
+
+const argv = process.argv.slice(2);
+
+const result = parseArgs(argv);
+
+if (!result.ok) {
+  process.stderr.write(logLine('error', errorText(result.error)) + '\n');
+  if (result.error.kind === 'missing-command') {
+    process.stderr.write(usageText() + '\n');
+  }
+  process.exitCode = result.error.exitCode;
+} else {
+  switch (result.command.kind) {
+    case 'help':
+      process.stdout.write(usageText() + '\n');
+      break;
+    case 'version':
+      process.stdout.write(versionText() + '\n');
+      break;
+    case 'doctor':
+    case 'curate':
+    case 'spawn':
+      process.stderr.write(logLine('warn', `not yet implemented: ${result.command.kind}`) + '\n');
+      process.exitCode = 1;
+      break;
+    default: {
+      const _exhaustive: never = result.command;
+      throw new Error(`unhandled command: ${(_exhaustive as { kind: string }).kind}`);
+    }
+  }
+}

--- a/dev/src/lib/core/cli/args.ts
+++ b/dev/src/lib/core/cli/args.ts
@@ -5,7 +5,7 @@ const HELP_FLAGS = new Set(['--help', '-h'] as const);
 
 export function parseArgs(argv: readonly string[]): ParseResult {
   if (argv.length === 0) {
-    return { ok: false, error: { kind: 'usage-error', message: 'missing command', exitCode: 2 } };
+    return { ok: false, error: { kind: 'missing-command', exitCode: 2 } };
   }
 
   const first = argv[0];
@@ -22,11 +22,11 @@ export function parseArgs(argv: readonly string[]): ParseResult {
   // Safe: .has() returns false for non-matching values; TS Set.has() requires element type
   if (COMMANDS.has(first as 'doctor' | 'curate' | 'spawn')) {
     if (argv.length > 1) {
-      return { ok: false, error: { kind: 'usage-error', message: `unexpected arguments: ${argv.slice(1).join(' ')}`, exitCode: 2 } };
+      return { ok: false, error: { kind: 'unexpected-args', args: argv.slice(1), exitCode: 2 } };
     }
     // Safe: guarded by COMMANDS.has() check above
     return { ok: true, command: { kind: first as 'doctor' | 'curate' | 'spawn' } };
   }
 
-  return { ok: false, error: { kind: 'usage-error', message: `unknown command: ${first}`, exitCode: 2 } };
+  return { ok: false, error: { kind: 'unknown-command', command: first, exitCode: 2 } };
 }

--- a/dev/src/lib/core/cli/output.ts
+++ b/dev/src/lib/core/cli/output.ts
@@ -1,4 +1,5 @@
 import { VERSION, COPYRIGHT_YEAR, AUTHOR } from '../../shared/constants.ts';
+import type { CliUsageError } from './types.ts';
 
 export function versionText(): string {
   return `ai4X, v${VERSION}, © ${COPYRIGHT_YEAR} ${AUTHOR}`;
@@ -17,4 +18,19 @@ export function usageText(): string {
     '  --help, -h     Show this help',
     '  --version      Show version',
   ].join('\n');
+}
+
+export function errorText(error: CliUsageError): string {
+  switch (error.kind) {
+    case 'missing-command':
+      return 'missing command';
+    case 'unknown-command':
+      return `unknown command: ${error.command}`;
+    case 'unexpected-args':
+      return `unexpected arguments: ${error.args.join(' ')}`;
+    default: {
+      const _exhaustive: never = error;
+      throw new Error(`unhandled error: ${(_exhaustive as { kind: string }).kind}`);
+    }
+  }
 }

--- a/dev/src/lib/core/cli/types.ts
+++ b/dev/src/lib/core/cli/types.ts
@@ -25,11 +25,27 @@ export type CliCommand =
   | CurateCommand
   | SpawnCommand;
 
-export interface CliUsageError {
-  readonly kind: 'usage-error';
-  readonly message: string;
-  readonly exitCode: number;
+export interface MissingCommandError {
+  readonly kind: 'missing-command';
+  readonly exitCode: 2;
 }
+
+export interface UnknownCommandError {
+  readonly kind: 'unknown-command';
+  readonly command: string;
+  readonly exitCode: 2;
+}
+
+export interface UnexpectedArgsError {
+  readonly kind: 'unexpected-args';
+  readonly args: readonly string[];
+  readonly exitCode: 2;
+}
+
+export type CliUsageError =
+  | MissingCommandError
+  | UnknownCommandError
+  | UnexpectedArgsError;
 
 export type ParseResult =
   | { readonly ok: true; readonly command: CliCommand }

--- a/dev/tst/app/ai4x.test.ts
+++ b/dev/tst/app/ai4x.test.ts
@@ -1,0 +1,148 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { execFile as execFileCb } from "node:child_process";
+import { promisify } from "node:util";
+import { fileURLToPath } from "node:url";
+import { resolve, dirname } from "node:path";
+
+const execFile = promisify(execFileCb);
+
+// CWD-independent path resolution (CA-05)
+const testDir = dirname(fileURLToPath(import.meta.url));
+const entryPoint = resolve(testDir, "../../src/app/ai4x.ts");
+
+async function run(
+  ...args: string[]
+): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+  try {
+    const { stdout, stderr } = await execFile(
+      process.execPath,
+      [entryPoint, ...args],
+      { encoding: "utf-8" },
+    );
+    return { stdout, stderr, exitCode: 0 };
+  } catch (err: unknown) {
+    // execFile rejects on non-zero exit; error object carries stdout, stderr, code.
+    // `as` justified: system boundary — child_process error shape is well-known but untyped.
+    const e = err as { stdout: string; stderr: string; code: number };
+    return { stdout: e.stdout, stderr: e.stderr, exitCode: e.code };
+  }
+}
+
+describe("ai4x CLI (integration)", () => {
+  describe("help flag", () => {
+    it("--help prints usage and exits 0", async () => {
+      const { stdout, stderr, exitCode } = await run("--help");
+      assert.equal(exitCode, 0);
+      assert.ok(stdout.includes("Usage: ai4x"), "stdout must contain 'Usage: ai4x'");
+      assert.equal(stderr, "");
+    });
+
+    it("-h prints usage and exits 0", async () => {
+      const { stdout, stderr, exitCode } = await run("-h");
+      assert.equal(exitCode, 0);
+      assert.ok(stdout.includes("Usage: ai4x"), "stdout must contain 'Usage: ai4x'");
+      assert.equal(stderr, "");
+    });
+  });
+
+  describe("version flag", () => {
+    it("--version prints version and exits 0", async () => {
+      const { stdout, stderr, exitCode } = await run("--version");
+      assert.equal(exitCode, 0);
+      assert.ok(stdout.includes("ai4X, v"), "stdout must contain 'ai4X, v'");
+      assert.equal(stderr, "");
+    });
+
+    it("--version with trailing args exits 0", async () => {
+      const { stdout, stderr, exitCode } = await run("--version", "extra");
+      assert.equal(exitCode, 0);
+      assert.ok(stdout.includes("ai4X, v"), "stdout must contain 'ai4X, v'");
+      assert.equal(stderr, "");
+    });
+  });
+
+  describe("sub-command stubs", () => {
+    it("doctor prints stub warning and exits 1", async () => {
+      const { stdout, stderr, exitCode } = await run("doctor");
+      assert.equal(exitCode, 1);
+      assert.equal(stdout, "");
+      assert.ok(
+        stderr.includes("[ai4X|warn] not yet implemented: doctor"),
+        "stderr must contain stub warning for doctor",
+      );
+    });
+
+    it("curate prints stub warning and exits 1", async () => {
+      const { stdout, stderr, exitCode } = await run("curate");
+      assert.equal(exitCode, 1);
+      assert.equal(stdout, "");
+      assert.ok(
+        stderr.includes("[ai4X|warn] not yet implemented: curate"),
+        "stderr must contain stub warning for curate",
+      );
+    });
+
+    it("spawn prints stub warning and exits 1", async () => {
+      const { stdout, stderr, exitCode } = await run("spawn");
+      assert.equal(exitCode, 1);
+      assert.equal(stdout, "");
+      assert.ok(
+        stderr.includes("[ai4X|warn] not yet implemented: spawn"),
+        "stderr must contain stub warning for spawn",
+      );
+    });
+  });
+
+  describe("error handling", () => {
+    it("bare invocation prints error + usage and exits 2", async () => {
+      const { stdout, stderr, exitCode } = await run();
+      assert.equal(exitCode, 2);
+      assert.equal(stdout, "");
+      assert.ok(
+        stderr.includes("[ai4X|error] missing command"),
+        "stderr must contain missing command error",
+      );
+      assert.ok(
+        stderr.includes("Usage: ai4x"),
+        "stderr must contain usage text on bare invocation",
+      );
+    });
+
+    it("unknown command prints error and exits 2", async () => {
+      const { stdout, stderr, exitCode } = await run("frobnicate");
+      assert.equal(exitCode, 2);
+      assert.equal(stdout, "");
+      assert.ok(
+        stderr.includes("[ai4X|error] unknown command: frobnicate"),
+        "stderr must contain unknown command error",
+      );
+    });
+
+    it("unexpected arguments prints error and exits 2", async () => {
+      const { stdout, stderr, exitCode } = await run("doctor", "extra");
+      assert.equal(exitCode, 2);
+      assert.equal(stdout, "");
+      assert.ok(
+        stderr.includes("[ai4X|error] unexpected arguments: extra"),
+        "stderr must contain unexpected arguments error",
+      );
+    });
+  });
+
+  describe("stream routing", () => {
+    it("help output goes to stdout, not stderr", async () => {
+      const { stdout, stderr, exitCode } = await run("--help");
+      assert.equal(exitCode, 0);
+      assert.ok(stdout.length > 0, "stdout must be non-empty for help");
+      assert.equal(stderr, "");
+    });
+
+    it("error output goes to stderr, not stdout", async () => {
+      const { stdout, stderr, exitCode } = await run("frobnicate");
+      assert.equal(exitCode, 2);
+      assert.equal(stdout, "");
+      assert.ok(stderr.length > 0, "stderr must be non-empty for errors");
+    });
+  });
+});

--- a/dev/tst/lib/core/cli/args.test.ts
+++ b/dev/tst/lib/core/cli/args.test.ts
@@ -44,35 +44,35 @@ describe("parseArgs", () => {
   });
 
   describe("error cases", () => {
-    it("returns usage error for empty argv", () => {
+    it("returns missing-command error for empty argv", () => {
       const result = parseArgs([]);
       assert.deepStrictEqual(result, {
         ok: false,
-        error: { kind: "usage-error", message: "missing command", exitCode: 2 },
+        error: { kind: "missing-command", exitCode: 2 },
       });
     });
 
-    it("returns usage error for unknown command", () => {
+    it("returns unknown-command error for unrecognized command", () => {
       const result = parseArgs(["frobnicate"]);
       assert.deepStrictEqual(result, {
         ok: false,
-        error: { kind: "usage-error", message: "unknown command: frobnicate", exitCode: 2 },
+        error: { kind: "unknown-command", command: "frobnicate", exitCode: 2 },
       });
     });
 
-    it("returns usage error for unknown flag", () => {
+    it("returns unknown-command error for unrecognized flag", () => {
       const result = parseArgs(["--unknown"]);
       assert.deepStrictEqual(result, {
         ok: false,
-        error: { kind: "usage-error", message: "unknown command: --unknown", exitCode: 2 },
+        error: { kind: "unknown-command", command: "--unknown", exitCode: 2 },
       });
     });
 
-    it("returns usage error when command has trailing arguments", () => {
+    it("returns unexpected-args error when command has trailing arguments", () => {
       const result = parseArgs(["doctor", "extra"]);
       assert.deepStrictEqual(result, {
         ok: false,
-        error: { kind: "usage-error", message: "unexpected arguments: extra", exitCode: 2 },
+        error: { kind: "unexpected-args", args: ["extra"], exitCode: 2 },
       });
     });
   });
@@ -82,7 +82,7 @@ describe("parseArgs", () => {
       const result = parseArgs(["doctor", "--help"]);
       assert.deepStrictEqual(result, {
         ok: false,
-        error: { kind: "usage-error", message: "unexpected arguments: --help", exitCode: 2 },
+        error: { kind: "unexpected-args", args: ["--help"], exitCode: 2 },
       });
     });
 

--- a/dev/tst/lib/core/cli/output.test.ts
+++ b/dev/tst/lib/core/cli/output.test.ts
@@ -1,7 +1,7 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 
-import { versionText, usageText } from "../../../../src/lib/core/cli/output.ts";
+import { versionText, usageText, errorText } from "../../../../src/lib/core/cli/output.ts";
 import { VERSION, COPYRIGHT_YEAR, AUTHOR } from "../../../../src/lib/shared/constants.ts";
 
 describe("versionText", () => {
@@ -42,5 +42,35 @@ describe("usageText", () => {
 
   it("is multi-line", () => {
     assert.ok(usageText().includes("\n"), "must contain newlines");
+  });
+});
+
+describe("errorText", () => {
+  it("returns 'missing command' for missing-command error", () => {
+    assert.equal(
+      errorText({ kind: "missing-command", exitCode: 2 }),
+      "missing command",
+    );
+  });
+
+  it("returns 'unknown command: <cmd>' for unknown-command error", () => {
+    assert.equal(
+      errorText({ kind: "unknown-command", command: "frobnicate", exitCode: 2 }),
+      "unknown command: frobnicate",
+    );
+  });
+
+  it("returns 'unexpected arguments: <arg>' for single unexpected arg", () => {
+    assert.equal(
+      errorText({ kind: "unexpected-args", args: ["extra"], exitCode: 2 }),
+      "unexpected arguments: extra",
+    );
+  });
+
+  it("joins multiple unexpected args with space", () => {
+    assert.equal(
+      errorText({ kind: "unexpected-args", args: ["--help", "foo"], exitCode: 2 }),
+      "unexpected arguments: --help foo",
+    );
   });
 });

--- a/dev/tst/lib/core/cli/types.test.ts
+++ b/dev/tst/lib/core/cli/types.test.ts
@@ -4,6 +4,9 @@ import assert from "node:assert/strict";
 import type {
   CliCommand,
   CliUsageError,
+  MissingCommandError,
+  UnknownCommandError,
+  UnexpectedArgsError,
   ParseResult,
   HelpCommand,
   VersionCommand,
@@ -33,45 +36,67 @@ describe("ParseResult narrowing", () => {
   it("grants access to error when ok is false", () => {
     const result: ParseResult = {
       ok: false,
-      error: { kind: "usage-error", message: "unknown flag", exitCode: 1 },
+      error: { kind: "missing-command", exitCode: 2 },
     };
 
     assert.equal(result.ok, false);
     if (!result.ok) {
-      assert.equal(result.error.kind, "usage-error");
-      assert.equal(result.error.message, "unknown flag");
-      assert.equal(result.error.exitCode, 1);
+      assert.equal(result.error.kind, "missing-command");
+      assert.equal(result.error.exitCode, 2);
     }
   });
 });
 
 describe("CliUsageError structure", () => {
-  it("has kind equal to usage-error", () => {
-    const err: CliUsageError = {
-      kind: "usage-error",
-      message: "bad input",
-      exitCode: 2,
-    };
-    assert.equal(err.kind, "usage-error");
+  it("each variant has a distinct kind value", () => {
+    const missing: MissingCommandError = { kind: "missing-command", exitCode: 2 };
+    const unknown: UnknownCommandError = { kind: "unknown-command", command: "x", exitCode: 2 };
+    const unexpected: UnexpectedArgsError = { kind: "unexpected-args", args: ["a"], exitCode: 2 };
+
+    const kinds = new Set([missing.kind, unknown.kind, unexpected.kind]);
+    assert.equal(kinds.size, 3, "all 3 kind values must be distinct");
   });
 
-  it("carries message and exitCode", () => {
-    const err: CliUsageError = {
-      kind: "usage-error",
-      message: "missing argument",
-      exitCode: 1,
-    };
-    assert.equal(err.message, "missing argument");
-    assert.equal(err.exitCode, 1);
+  it("MissingCommandError has kind missing-command and exitCode 2", () => {
+    const err: MissingCommandError = { kind: "missing-command", exitCode: 2 };
+    assert.equal(err.kind, "missing-command");
+    assert.equal(err.exitCode, 2);
   });
 
-  it("is a plain data record, not an Error instance", () => {
-    const err: CliUsageError = {
-      kind: "usage-error",
-      message: "test",
-      exitCode: 1,
-    };
-    assert.equal(err instanceof Error, false);
+  it("UnknownCommandError carries a command string", () => {
+    const err: UnknownCommandError = { kind: "unknown-command", command: "frobnicate", exitCode: 2 };
+    assert.equal(err.kind, "unknown-command");
+    assert.equal(err.command, "frobnicate");
+    assert.equal(err.exitCode, 2);
+  });
+
+  it("UnexpectedArgsError carries an args array", () => {
+    const err: UnexpectedArgsError = { kind: "unexpected-args", args: ["extra", "stuff"], exitCode: 2 };
+    assert.equal(err.kind, "unexpected-args");
+    assert.deepEqual(err.args, ["extra", "stuff"]);
+    assert.equal(err.exitCode, 2);
+  });
+
+  it("all variants have exitCode 2", () => {
+    const errors: CliUsageError[] = [
+      { kind: "missing-command", exitCode: 2 },
+      { kind: "unknown-command", command: "x", exitCode: 2 },
+      { kind: "unexpected-args", args: [], exitCode: 2 },
+    ];
+    for (const err of errors) {
+      assert.equal(err.exitCode, 2);
+    }
+  });
+
+  it("none are Error instances", () => {
+    const errors: CliUsageError[] = [
+      { kind: "missing-command", exitCode: 2 },
+      { kind: "unknown-command", command: "x", exitCode: 2 },
+      { kind: "unexpected-args", args: [], exitCode: 2 },
+    ];
+    for (const err of errors) {
+      assert.equal(err instanceof Error, false);
+    }
   });
 });
 


### PR DESCRIPTION
## Story #5: CLI Entry Point and Integration Tests

### Changes
- **Entry point** (`dev/src/app/ai4x.ts`): Pure-lib dispatch, side effects isolated to app layer
- **CliUsageError ADT rework**: Discriminated union with `kind` discriminator (`missing-command`, `unknown-command`, `unexpected-args`)
- **`errorText()` formatter** (`dev/src/lib/core/cli/output.ts`): Exhaustive pattern matching, no string comparison
- **Integration tests** (`dev/tst/app/ai4x.test.ts`): 12 tests via `execFile`, CWD-independent
- **Engine bump**: `>=23.6.0` (native TS stripping, no `--experimental-strip-types`)
- **Governance contracts**: Updated to enforce discriminated error variants and literal types

### Test Evidence
- 57 tests (45 unit + 12 integration), 0 failures
- Typecheck: 0 errors

### Review History
- Review A (Stage 4): CA-01..CA-10 — all resolved
- Review B (Stage 8b): NF-01 (missing integration test for unexpected-args) — resolved

### Conformance
Session conformance check passed (all artifacts present, no contradictions, no unresolved findings).

Closes #5