### PR TITLE
chore: resolve review findings from Epic #9

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -130,13 +130,7 @@ source /usr/local/share/fish/vendor_completions.d/ai4x.fish
 make verify    # check repository baseline paths and artifacts
 make doctor    # validate repository structure readiness
 make clean     # remove local build/runtime artifacts
-make test      # run verify baseline checks
-```
-
-To run the full test suite:
-
-```bash
-cd dev && npm test
+make test      # run verify + Node.js test suite
 ```
 
 `make clean && npm ci --prefix dev && make install` is the full reset path.

--- a/Makefile
+++ b/Makefile
@@ -55,10 +55,14 @@ uninstall:
 	@rm -f "$(DESTDIR)$(BASH_COMPLETION_DIR)/ai4x"
 	@rm -f "$(DESTDIR)$(ZSH_COMPLETION_DIR)/_ai4x"
 	@rm -f "$(DESTDIR)$(FISH_COMPLETION_DIR)/ai4x.fish"
+	@-rmdir -p "$(DESTDIR)$(BINDIR)" 2>/dev/null || true
+	@-rmdir -p "$(DESTDIR)$(BASH_COMPLETION_DIR)" 2>/dev/null || true
+	@-rmdir -p "$(DESTDIR)$(ZSH_COMPLETION_DIR)" 2>/dev/null || true
+	@-rmdir -p "$(DESTDIR)$(FISH_COMPLETION_DIR)" 2>/dev/null || true
 	@echo '[ai4x] uninstalled (user config preserved)'
 
 clean:
-	@PREFIX="$(PREFIX)" DESTDIR="$(DESTDIR)" bash ./utl/ops/clean.sh
+	@bash ./utl/ops/clean.sh
 
 doctor:
 	@PREFIX="$(PREFIX)" DESTDIR="$(DESTDIR)" bash ./utl/ops/doctor.sh
@@ -67,3 +71,4 @@ verify:
 	@bash ./utl/ops/verify.sh
 
 test: verify
+	@cd dev && npm test

--- a/dev/tst/utl/ops/makefile-install.test.ts
+++ b/dev/tst/utl/ops/makefile-install.test.ts
@@ -348,4 +348,54 @@ describe("Makefile install/uninstall (Story #11)", () => {
       );
     });
   });
+
+  // ── Idempotency and Adversarial (#16) ────────────────────────────
+
+  describe("idempotency and adversarial (#16)", () => {
+    it("install twice in succession succeeds", () => {
+      const destdir = `/tmp/ai4x-test-idempotent-${process.pid}`;
+      const configDir = `/tmp/ai4x-test-idempotent-config-${process.pid}`;
+      cleanup(destdir);
+      cleanup(configDir);
+      try {
+        const first = runMake("install", { DESTDIR: destdir }, { XDG_CONFIG_HOME: configDir });
+        assert.equal(first.exitCode, 0, `first install failed: ${first.stderr}`);
+        const second = runMake("install", { DESTDIR: destdir }, { XDG_CONFIG_HOME: configDir });
+        assert.equal(second.exitCode, 0, `second install failed: ${second.stderr}`);
+        assert.ok(existsSync(`${destdir}/usr/local/bin/ai4x`), "launcher must exist after double install");
+      } finally {
+        cleanup(destdir);
+        cleanup(configDir);
+      }
+    });
+
+    it("uninstall when nothing is installed succeeds", () => {
+      const destdir = `/tmp/ai4x-test-noop-uninstall-${process.pid}`;
+      cleanup(destdir);
+      try {
+        const result = runMake("uninstall", { DESTDIR: destdir });
+        assert.equal(result.exitCode, 0, `uninstall on empty DESTDIR failed: ${result.stderr}`);
+      } finally {
+        cleanup(destdir);
+      }
+    });
+
+    it("DESTDIR with spaces works correctly", () => {
+      const destdir = `/tmp/ai4x test spaces ${process.pid}`;
+      const configDir = `/tmp/ai4x-test-spaces-config-${process.pid}`;
+      cleanup(destdir);
+      cleanup(configDir);
+      try {
+        const install = runMake("install", { DESTDIR: destdir }, { XDG_CONFIG_HOME: configDir });
+        assert.equal(install.exitCode, 0, `install with spaces failed: ${install.stderr}`);
+        assert.ok(existsSync(`${destdir}/usr/local/bin/ai4x`), "launcher must exist at spaced path");
+        const uninstall = runMake("uninstall", { DESTDIR: destdir });
+        assert.equal(uninstall.exitCode, 0, `uninstall with spaces failed: ${uninstall.stderr}`);
+        assert.ok(!existsSync(`${destdir}/usr/local/bin/ai4x`), "launcher must be removed");
+      } finally {
+        cleanup(destdir);
+        cleanup(configDir);
+      }
+    });
+  });
 });


### PR DESCRIPTION
## Chore Batch — Review Findings

Closes #14, closes #16, closes #17, closes #18

### Changes

| Issue | Fix |
|-------|-----|
| **#14** | `make test` now runs `verify` + `cd dev && npm test` |
| **#16** | 3 new tests: double install (idempotency), noop uninstall, DESTDIR with spaces |
| **#17** | `make uninstall` prunes empty parent dirs via `rmdir -p` (BINDIR + all completion dirs) |
| **#18** | `clean` target no longer passes unused PREFIX/DESTDIR to `clean.sh` |

Also updates INSTALL diagnostics section to reflect `make test` behavior.

### Test Results

- 132 tests pass, 0 fail (3 new for #16)
- `tsc --noEmit`: zero errors
- `make verify`: green