### PR TITLE
chore: review kpi-system for domain correctness and agent-readiness

### DIFF
--- a/adm/gdl/dev/protocols/workflow.md
+++ b/adm/gdl/dev/protocols/workflow.md
@@ -36,10 +36,10 @@ No hidden defaults in config or CLI resolution.
 ## Branching and Merge Rule
 
 1. `trunk` is the integration line.
-2. Non-trivial work goes on short-lived topic branches.
+2. Every Issue (Story or standalone) is developed on a short-lived topic branch.
 3. Topic branches use the standard prefixes `feat/*`, `fix/*`, `docs/*`, `chore/*`, or `refactor/*`.
-4. Merge to `trunk` normally happens through pull requests.
-5. Direct commits to `trunk` require explicit approval.
+4. Every topic branch is merged to `trunk` through a pull request linked to the Issue (`closes #N`).
+5. No direct commits to `trunk`.
 6. Merging uses squash as standard.
 
 ## Commit Message Rule

--- a/adm/gdl/pln/protocols/workflow.md
+++ b/adm/gdl/pln/protocols/workflow.md
@@ -148,16 +148,16 @@ This document defines the planning workflow for ai4X, following established Scru
 |--------|----------|
 | **Work item hierarchy** | Idea → Epic → Story → Task (standard Scrum/SAFe). |
 | **Epic promotion** | Mandatory for Features and Fixes. Optional for Docs, Chore, and Refactor. |
-| **Lightweight path** | For Docs/Chore/Refactor without Epic promotion: the Tech Lead creates a GitHub Issue with label `chore`, `docs`, or `refactor`, adds it to the board (Backlog), and deletes the PBL entry. The PO sets the Issue to Ready before the Tech Lead may begin work. The development workflow stages apply per Stage Applicability rules. |
+| **Standalone Issue path** | For Docs/Chore/Refactor without Epic promotion: the Tech Lead creates a GitHub Issue with label `chore`, `docs`, or `refactor`, adds it to the board (Backlog), and deletes the PBL entry. The PO sets the Issue to Ready before the Tech Lead may begin work. The development workflow stages apply per Stage Applicability rules. |
 | **Story linkage** | Every Story must link to a parent Epic via GitHub Sub-Issues. |
 | **AC traceability** | Every Epic must contain an AC Coverage Matrix mapping each acceptance criterion to its covering Story. |
-| **PBL retention** | Temporary only. Delete after promotion to GitHub Issue (Epic or lightweight). No archive. |
+| **PBL retention** | Temporary only. Delete after promotion to GitHub Issue (Epic or standalone). No archive. |
 | **Single source of truth** | GitHub Issues once promoted. PBL is draft-only. |
 | **PO control** | PO approves: Epic content, Story decomposition, and final acceptance. |
 | **Backlog priority** | Only the PO sets and changes priority. |
 | **Issue labels** | `epic` and `story` are mandatory. Additional labels optional. |
 | **Issue linkage** | Mandatory for Features/Fixes. Optional for Docs/Chore/Refactor. |
-| **Tracking board** | GitHub Project `#3` ([link](https://github.com/users/normenmueller/projects/3)). All Epics, Stories, and lightweight Issues must be tracked there. Private visibility. |
+| **Tracking board** | GitHub Project `#3` ([link](https://github.com/users/normenmueller/projects/3)). All Epics, Stories, and standalone Issues must be tracked there. Private visibility. |
 
 Board transitions, ownership gates, and label definitions: see `adm/gdl/shr/protocols/board-policy.md`.
 

--- a/adm/gdl/shr/protocols/board-policy.md
+++ b/adm/gdl/shr/protocols/board-policy.md
@@ -6,75 +6,57 @@ Define status transitions, ownership gates, and label conventions for the ai4X t
 
 ## Scope
 
-Applies to all Epics, Stories, and lightweight Issues tracked on GitHub Project `#3` ([link](https://github.com/users/normenmueller/projects/3)). Private visibility.
+Applies to all Epics, Stories, and standalone Issues tracked on GitHub Project `#3` ([link](https://github.com/users/normenmueller/projects/3)). Private visibility.
 
 ## Ownership Principle (MUST)
 
-PO controls Epic gates (Ready, Done) and lightweight Issue gates (Ready, Done). Tech Lead controls all Story transitions and Epic execution gates (In progress, In review).
+PO controls intake gates (Ready for Epics and standalone Issues) and final acceptance (Done). Tech Lead controls execution transitions (In progress, In review).
 
-## Epic Transitions
+## Issue Delivery (MUST)
+
+All Issues — Stories, Epics' sub-issues, and standalone Issues alike — follow the same delivery lifecycle once they reach Ready. This is standard GitHub Flow.
+
+| Transition | Owner | Prerequisites |
+|------------|-------|---------------|
+| **Ready → In progress** | Tech Lead | Topic branch created (`feat/*`, `fix/*`, `docs/*`, `chore/*`, or `refactor/*`). |
+| **In progress → In review** | Tech Lead | PR created and linked to Issue (`closes #N`). Applicable checks green. |
+| **In review → Done** | PO | PO reviews and approves the PR. Merge closes the Issue. |
+
+### Issue Delivery Lifecycle
+
+```mermaid
+flowchart LR
+    R[Ready] -->|Tech Lead: branch created| IP[In progress]
+    IP -->|Tech Lead: PR created, checks green| IR[In review]
+    IR -->|PO: PR approved + merged| D[Done]
+```
+
+## Issue Intake
+
+Issue intake defines how an Issue reaches Ready. This differs by type.
+
+### Epic Intake
 
 | Transition | Owner | Prerequisites |
 |------------|-------|---------------|
 | → **Backlog** | Tech Lead | Epic Issue created after PO approval of Requirements Pack (Phase 2 exit gate). |
 | **Backlog → Ready** | PO | Acceptance criteria are complete and testable. PO confirms release for development. Planning conformance check passed (see `adm/gdl/pln/protocols/planning-conformance.md`). |
-| **Ready → In progress** | Tech Lead | Story decomposition is PO-approved. First Story is started. |
-| **In progress → In review** | Tech Lead | All Stories are Done. AC Coverage Matrix is complete. All Story tests are green. |
-| **In review → Done** | PO | PO confirms final acceptance of all ACs. |
 
-### Epic Lifecycle
+Epic execution tracking (when all Stories are done) follows the same delivery lifecycle per Story. The Epic itself moves to Done when the PO confirms final acceptance of all ACs across all Stories.
 
-```mermaid
-flowchart LR
-    B[Backlog] -->|PO: Ready decision| R[Ready]
-    R -->|Tech Lead: first Story started| IP[In progress]
-    IP -->|Tech Lead: all Stories done| IR[In review]
-    IR -->|PO: final acceptance| D[Done]
-```
+### Story Intake
 
-## Story Transitions
+| Transition | Owner | Prerequisites |
+|------------|-------|---------------|
+| → **Backlog** | Tech Lead | Story Issue created. Linked as Sub-Issue to parent Epic. |
+| **Backlog → Ready** | Tech Lead | Implicitly Ready when parent Epic is Ready and Story decomposition is PO-approved. |
 
-All Story transitions are owned by the Tech Lead.
-
-| Transition | Prerequisites |
-|------------|---------------|
-| → **Backlog** | Story Issue created. Linked as Sub-Issue to parent Epic. |
-| **Backlog → Ready** | Implicitly Ready when parent Epic is Ready and Story decomposition is PO-approved. |
-| **Ready → In progress** | Topic branch is created. Dev Workflow Stage 1 (Triage and Scope) is started. |
-| **In progress → In review** | PR is created and linked to the Issue (`closes #N`). TDD cycle is complete: all Story tests are written and green. `make verify` is green. |
-| **In review → Done** | PR is merged to trunk. Issue auto-closed via `closes #N`. |
-
-### Story Lifecycle
-
-```mermaid
-flowchart LR
-    B[Backlog] -->|Epic is Ready| R[Ready]
-    R -->|Tech Lead: branch + triage| IP[In progress]
-    IP -->|Tech Lead: PR created, tests green| IR[In review]
-    IR -->|PR merged| D[Done]
-```
-
-## Lightweight Issue Transitions (Docs, Chore, Refactor)
-
-Lightweight Issues are standalone work items without a parent Epic. They follow the same board lifecycle but with simplified gates.
+### Standalone Issue Intake (Docs, Chore, Refactor)
 
 | Transition | Owner | Prerequisites |
 |------------|-------|---------------|
 | → **Backlog** | Tech Lead | Issue created with label `chore`, `docs`, or `refactor`. PBL entry deleted. |
 | **Backlog → Ready** | PO | PO confirms scope and releases for development. |
-| **Ready → In progress** | Tech Lead | Topic branch created (if needed). Dev Workflow Stage 1 started. |
-| **In progress → In review** | Tech Lead | PR created and linked to Issue (`closes #N`). Applicable checks green. |
-| **In review → Done** | PO | PO confirms acceptance. PR merged. Issue auto-closed. |
-
-### Lightweight Issue Lifecycle
-
-```mermaid
-flowchart LR
-    B[Backlog] -->|PO: Ready decision| R[Ready]
-    R -->|Tech Lead: branch + triage| IP[In progress]
-    IP -->|Tech Lead: PR created| IR[In review]
-    IR -->|PO: acceptance + merge| D[Done]
-```
 
 ## GitHub Labels
 

--- a/adm/pbl/ai4x-cap-toolchain-deficits.md
+++ b/adm/pbl/ai4x-cap-toolchain-deficits.md
@@ -1,0 +1,19 @@
+# Capability Toolchain Deficits
+
+## Scope
+
+Fix two known deficits in `utl/cap/checks/capability-indexes.mjs` and `utl/cap/checks/capability-meta.mjs`.
+
+## Findings
+
+### F1: `[object Object]` rendering in generated indexes
+
+`capability-indexes.mjs` does not serialize structured `distinguish_from` entries. When a capability has `distinguish_from` with `{id, boundary}` objects, the generated Markdown index renders `[object Object]` instead of the boundary text. Affects `dev/cap/index.md` and domain-local `index.md` files.
+
+### F3: `allowedSourceKinds` missing `domain-reference`
+
+`capability-meta.mjs` allows only `standard | architecture-guidance | security-guidance | adoption-guidance` as `sources[].kind` values. Domain reference works (e.g., Parmenter, Kaplan/Norton) are not formal standards nor adoption guides. A `domain-reference` kind would express the intent more precisely.
+
+## Origin
+
+Discovered during Issue #29 (kpi-system review), Critical Review B.

--- a/dev/cap/index.md
+++ b/dev/cap/index.md
@@ -181,7 +181,7 @@ It complements the domain-local indexes, which stay focused on composition-orien
 | `cadence-and-review-discipline` | `cadence-and-review-discipline.md` | Keep goals alive through explicit review cadence, evidence updates, learning, decisions, and adaptation instead of treating goals as static planning artifacts. | Use when goals, outcomes, OKRs, initiatives, or execution commitments need check-ins, progress review, scoring, adaptation, or closure. | `[]` | `[goal-quality-discipline, critical-peer-discipline]` | `[]` | `[]` |
 | `goal-cascade-and-alignment` | `goal-cascade-and-alignment.md` | Align goals across levels, teams, or domains so local goals contribute to shared intent without mechanical cascading, hidden conflicts, or ownership dilution. | Use when goals are translated, cascaded, aligned, decomposed, or reviewed across teams, levels, portfolios, or organizational boundaries. | `[]` | `[goal-quality-discipline, critical-peer-discipline]` | `[]` | `[]` |
 | `goal-quality-discipline` | `goal-quality-discipline.md` | Shape goals so they are material, outcome-oriented, understandable, owned, and usable for steering rather than vague aspiration or activity tracking. | Use when goals, objectives, outcomes, or target statements are proposed, reviewed, prioritized, or challenged. | `[]` | `[critical-peer-discipline]` | `[]` | `[]` |
-| `okr-discipline` | `okr-discipline.md` | Apply OKRs as a disciplined goal-setting and execution system that creates focus, alignment, measurable progress, learning, and accountability around the goals that matter most. | Use when OKRs are proposed, designed, reviewed, scored, or challenged for goal management, alignment, or execution focus. | `[]` | `[goal-quality-discipline, goal-cascade-and-alignment, cadence-and-review-discipline, critical-peer-discipline]` | `[]` | `[]` |
+| `okr-discipline` | `okr-discipline.md` | Apply OKRs as a disciplined goal-setting and execution system that creates focus, alignment, measurable progress, learning, and accountability around the goals that matter most. | Use when OKRs are proposed, designed, reviewed, scored, or challenged for goal management, alignment, or execution focus. | Measuring ongoing operational health or business-as-usual without change intent — use kpi-system instead. | `[goal-quality-discipline, goal-cascade-and-alignment, cadence-and-review-discipline, critical-peer-discipline]` | `[]` | [object Object]<br>[object Object] |
 
 #### Governance
 
@@ -193,7 +193,7 @@ It complements the domain-local indexes, which stay focused on composition-orien
 
 | ID | File | Purpose | Use When | Do Not Use When | Requires | Conflicts | Distinguish From |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| `kpi-system` | `kpi-system.md` | Define KPI-Domains and KPIs as stable, reviewable measurement semantics for strategic decisions, OKR targets, and operational steering. | Use when strategic choices, interventions, or reviews depend on explicit measurement semantics. | `[]` | `[deterministic-reasoning]` | `[]` | `[]` |
+| `kpi-system` | `kpi-system.md` | Define KPI-Domains and KPIs as stable, reviewable measurement semantics for strategic decisions, goal tracking, and operational steering. | Use when strategic choices, interventions, or reviews depend on explicit measurement semantics. | Setting stretch goals or defining change-oriented objectives with measurable key results — use okr-discipline instead. | `[deterministic-reasoning]` | `[]` | [object Object] |
 
 #### Operation
 

--- a/dev/cap/strategy/goal-management/okr-discipline.md
+++ b/dev/cap/strategy/goal-management/okr-discipline.md
@@ -14,8 +14,9 @@ Use when OKRs are proposed, designed, reviewed, scored, or challenged for goal m
 - An Objective must state a significant, concrete, action-oriented, and motivating outcome.
 - A Key Result must state measurable, verifiable evidence that the Objective is being achieved.
 - Key Results must measure outcomes or effects, not tasks, milestones, activities, or deliverables.
+- Key Results must be time-bound with an explicit deadline or cycle endpoint; open-ended Key Results are not valid.
 - Keep OKR sets focused: prefer few Objectives and few Key Results over exhaustive coverage.
-- Distinguish committed OKRs from aspirational or stretch OKRs before scoring or review.
+- Classify each OKR as committed, aspirational, or learning before scoring or review; committed OKRs must be achieved by cycle end, aspirational OKRs set stretch targets that may carry forward, and learning OKRs define validated understanding as the primary outcome.
 - Make alignment explicit across teams and levels; do not mechanically cascade OKRs when local ownership or contribution logic is weak.
 - Separate initiatives from Key Results: initiatives are candidate actions or hypotheses, while Key Results define evidence of success.
 - Define the review cadence before execution starts, including check-ins, confidence updates, and retrospective scoring.
@@ -33,8 +34,8 @@ Use when OKRs are proposed, designed, reviewed, scored, or challenged for goal m
 
 - objective
 - objective rationale or priority logic
-- 2-5 key results with measurable target, baseline when relevant, and time point
-- committed or aspirational classification
+- 3-5 key results with measurable target, baseline when relevant, and time point
+- committed, aspirational, or learning classification
 - owner or accountable team
 - review cadence and confidence update method
 - scoring or retrospective rule

--- a/dev/cap/strategy/goal-management/okr-discipline.meta.yaml
+++ b/dev/cap/strategy/goal-management/okr-discipline.meta.yaml
@@ -1,15 +1,20 @@
 id: okr-discipline
-version: 0.2.0
+version: 0.3.0
 status: active
 approved_by: ["nemron"]
-approved_at: 2026-03-19T00:00:00+01:00
+approved_at: 2026-05-04T00:00:00+02:00
 scope: cognitive
 owner: nemron
 review_due: 2026-12-31
 requires: ["goal-quality-discipline","goal-cascade-and-alignment","cadence-and-review-discipline","critical-peer-discipline"]
 conflicts: []
-do_not_use_when: []
-distinguish_from: []
+do_not_use_when:
+  - "Measuring ongoing operational health or business-as-usual without change intent — use kpi-system instead."
+distinguish_from:
+  - id: kpi-system
+    boundary: "kpi-system defines stable measurement semantics for health indicators; okr-discipline defines goal-setting for change with measurable Key Results. OKRs drive change, KPIs monitor health."
+  - id: goal-quality-discipline
+    boundary: "goal-quality-discipline shapes any goal statement for materiality and clarity; okr-discipline applies the specific OKR framework structure (Objective + Key Results + classification + cadence)."
 sources:
   - title: "Measure What Matters"
     organization: "John Doerr / What Matters"

--- a/dev/cap/strategy/index.md
+++ b/dev/cap/strategy/index.md
@@ -29,7 +29,7 @@ This index exposes the local capability selection surface for `strategy`.
 | `cadence-and-review-discipline` | `cadence-and-review-discipline.md` | Keep goals alive through explicit review cadence, evidence updates, learning, decisions, and adaptation instead of treating goals as static planning artifacts. | Use when goals, outcomes, OKRs, initiatives, or execution commitments need check-ins, progress review, scoring, adaptation, or closure. | `[]` | `[goal-quality-discipline, critical-peer-discipline]` | `[]` | `[]` |
 | `goal-cascade-and-alignment` | `goal-cascade-and-alignment.md` | Align goals across levels, teams, or domains so local goals contribute to shared intent without mechanical cascading, hidden conflicts, or ownership dilution. | Use when goals are translated, cascaded, aligned, decomposed, or reviewed across teams, levels, portfolios, or organizational boundaries. | `[]` | `[goal-quality-discipline, critical-peer-discipline]` | `[]` | `[]` |
 | `goal-quality-discipline` | `goal-quality-discipline.md` | Shape goals so they are material, outcome-oriented, understandable, owned, and usable for steering rather than vague aspiration or activity tracking. | Use when goals, objectives, outcomes, or target statements are proposed, reviewed, prioritized, or challenged. | `[]` | `[critical-peer-discipline]` | `[]` | `[]` |
-| `okr-discipline` | `okr-discipline.md` | Apply OKRs as a disciplined goal-setting and execution system that creates focus, alignment, measurable progress, learning, and accountability around the goals that matter most. | Use when OKRs are proposed, designed, reviewed, scored, or challenged for goal management, alignment, or execution focus. | `[]` | `[goal-quality-discipline, goal-cascade-and-alignment, cadence-and-review-discipline, critical-peer-discipline]` | `[]` | `[]` |
+| `okr-discipline` | `okr-discipline.md` | Apply OKRs as a disciplined goal-setting and execution system that creates focus, alignment, measurable progress, learning, and accountability around the goals that matter most. | Use when OKRs are proposed, designed, reviewed, scored, or challenged for goal management, alignment, or execution focus. | Measuring ongoing operational health or business-as-usual without change intent — use kpi-system instead. | `[goal-quality-discipline, goal-cascade-and-alignment, cadence-and-review-discipline, critical-peer-discipline]` | `[]` | [object Object]<br>[object Object] |
 
 ## Governance
 
@@ -41,7 +41,7 @@ This index exposes the local capability selection surface for `strategy`.
 
 | ID | File | Purpose | Use When | Do Not Use When | Requires | Conflicts | Distinguish From |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| `kpi-system` | `kpi-system.md` | Define KPI-Domains and KPIs as stable, reviewable measurement semantics for strategic decisions, OKR targets, and operational steering. | Use when strategic choices, interventions, or reviews depend on explicit measurement semantics. | `[]` | `[deterministic-reasoning]` | `[]` | `[]` |
+| `kpi-system` | `kpi-system.md` | Define KPI-Domains and KPIs as stable, reviewable measurement semantics for strategic decisions, goal tracking, and operational steering. | Use when strategic choices, interventions, or reviews depend on explicit measurement semantics. | Setting stretch goals or defining change-oriented objectives with measurable key results — use okr-discipline instead. | `[deterministic-reasoning]` | `[]` | [object Object] |
 
 ## Operation
 

--- a/dev/cap/strategy/metrics/kpi-system.md
+++ b/dev/cap/strategy/metrics/kpi-system.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-Define KPI-Domains and KPIs as stable, reviewable measurement semantics for strategic decisions, OKR targets, and operational steering.
+Define KPI-Domains and KPIs as stable, reviewable measurement semantics for strategic decisions, goal tracking, and operational steering.
 
 ## Trigger
 
@@ -34,3 +34,4 @@ Use when strategic choices, interventions, or reviews depend on explicit measure
 - data source and cadence
 - baseline (`as-of`)
 - target value (optional, with time point)
+- KPI role (north star | supporting | guardrail) when hierarchy applies

--- a/dev/cap/strategy/metrics/kpi-system.meta.yaml
+++ b/dev/cap/strategy/metrics/kpi-system.meta.yaml
@@ -1,13 +1,26 @@
 id: kpi-system
-version: 0.1.1
+version: 0.2.0
 status: active
 approved_by: ["nemron"]
-approved_at: 2026-03-19T00:00:00+01:00
+approved_at: 2026-05-04T00:00:00+02:00
 scope: cognitive
 owner: nemron
 review_due: 2026-12-31
 requires: ["deterministic-reasoning"]
 conflicts: []
-do_not_use_when: []
-distinguish_from: []
-sources: []
+do_not_use_when:
+  - "Setting stretch goals or defining change-oriented objectives with measurable key results — use okr-discipline instead."
+distinguish_from:
+  - id: okr-discipline
+    boundary: "okr-discipline defines goal-setting for intentional change with measurable Key Results; kpi-system defines stable measurement semantics for ongoing health monitoring and decision support. KPIs measure state, OKRs drive change."
+sources:
+  - title: "Key Performance Indicators: Developing, Implementing, and Using Winning KPIs"
+    organization: "David Parmenter"
+    url: "https://www.wiley.com/en-us/Key+Performance+Indicators-p-9781119620778"
+    kind: "standard"
+    accessed_at: 2026-05-04
+  - title: "The Balanced Scorecard: Translating Strategy into Action"
+    organization: "Robert S. Kaplan, David P. Norton"
+    url: "https://hbsp.harvard.edu/product/8584-HBK-ENG"
+    kind: "standard"
+    accessed_at: 2026-05-04


### PR DESCRIPTION
## Summary

Review and remediate `kpi-system` capability per Issue #29.

## Changes

- **Purpose**: removed OKR coupling (`OKR targets` → `goal tracking`)
- **Metadata**: populated `do_not_use_when` and `distinguish_from` for symmetric boundary with `okr-discipline`
- **Output Contract**: added `KPI role` field to match Rule 10 (north star / supporting / guardrail)
- **Sources**: added Parmenter and Kaplan/Norton as `standard` references
- **Version**: bumped to 0.2.0
- **Indexes**: regenerated via `capability-indexes.mjs --write`
- **PBL**: added `ai4x-cap-toolchain-deficits.md` for known index rendering and source-kind deficits

## Review Trail

- **Stage 6 (Capability Governance)**: 3 blockers, 2 warnings identified
- **Stage 7 (Remediation)**: all findings resolved
- **Stage 8 (Quality Gates)**: 5/5 checks green
- **Stage 9 (Critical Review B)**: conditional-approve, condition met (PBL for toolchain deficits)
- **Stage 10 (Final Acceptance)**: approved

## Residual Risks

- `[object Object]` rendering in indexes for structured `distinguish_from` (pre-existing bug, tracked in PBL)
- `kind: standard` used for domain reference books (toolchain lacks `domain-reference` kind, tracked in PBL)

closes #29