### PR TITLE
chore: add determinism priority rule to engineering quality contract

### DIFF
--- a/adm/gdl/dev/contracts/engineering-quality.md
+++ b/adm/gdl/dev/contracts/engineering-quality.md
@@ -95,3 +95,13 @@ All written artifacts must use English.
 - All documentation, README content, and inline doc comments must be in English.
 - All commit messages, branch names, GitHub Issue titles/descriptions, and PR content must be in English.
 - Conversational interaction with the PO is in German; this rule applies only to persisted artifacts.
+
+## Determinism Priority (MUST)
+
+Prefer deterministic solutions over LLM-based solutions.
+
+- What can be decided by rules, graph traversal, constraint checking, or structured data must not be delegated to an LLM.
+- LLM involvement is justified only where semantic judgment is required that no rule system can reliably cover.
+- Every design that involves AI components must make the deterministic/indeterministic boundary explicit.
+- Deterministic components must be testable without LLM involvement.
+- When uncertain whether a task requires LLM judgment, default to a deterministic implementation and escalate the decision.


### PR DESCRIPTION
## Summary

Add **Determinism Priority (MUST)** rule to `engineering-quality.md`.

Deterministic solutions take precedence over LLM-based solutions. LLM involvement is justified only where semantic judgment is required that no rule system can reliably cover.

Placed in `engineering-quality.md` (the base contract all specialists depend on) so the principle applies across AI strategy, architecture, and implementation work.

## Origin

PO directive during Schema-First Capability Metadata Redesign interview (Phase 2). Cross-cutting design principle identified as team-wide rule, not requirement-specific.