### PR TITLE
chore: add Single Authoritative Source principle, rename Metadata-Text Boundary

### DIFF
--- a/adm/gdl/dev/contracts/capability-authoring-governance.md
+++ b/adm/gdl/dev/contracts/capability-authoring-governance.md
@@ -55,7 +55,7 @@ It does not define curatable runtime behavior bundles; those belong in the capab
 - Neighboring capabilities must keep terminology and semantic boundaries consistent enough that the same semantic core is not silently renamed or ambiguously duplicated.
 - New or materially changed capabilities must be admitted only after explicit nearest-neighbor comparison and primary semantic owner judgment.
 
-# Schema-Text Boundary
+# Metadata-Text Boundary
 
 Capability text and metadata serve different consumers and must not duplicate information.
 

--- a/adm/gdl/dev/contracts/engineering-quality.md
+++ b/adm/gdl/dev/contracts/engineering-quality.md
@@ -105,3 +105,12 @@ Prefer deterministic solutions over LLM-based solutions.
 - Every design that involves AI components must make the deterministic/indeterministic boundary explicit.
 - Deterministic components must be testable without LLM involvement.
 - When uncertain whether a task requires LLM judgment, default to a deterministic implementation and escalate the decision.
+
+## Single Authoritative Source (MUST)
+
+No artifact may redundantly store data that is deterministically derivable from an authoritative source.
+
+- If information is already canonical in Git history, filesystem structure, a registry, or another designated source of truth, it must not be duplicated in metadata, prose, or configuration.
+- Derived data may be generated into transient or cached artifacts, but those are not sources of truth.
+- When a field or section is found to duplicate an authoritative source, it must be removed and its consumers redirected to the canonical source.
+- Tooling must derive rather than require manual synchronization.


### PR DESCRIPTION
## Summary

Two governance changes:

### 1. Single Authoritative Source (MUST) — `engineering-quality.md`

Universal engineering principle: No artifact may redundantly store data that is deterministically derivable from an authoritative source (Git history, filesystem structure, registry, etc.). Derived data belongs in generated/cached artifacts, not in manually maintained fields.

Placed after Determinism Priority — both are foundational engineering constraints.

### 2. Rename Schema-Text Boundary → Metadata-Text Boundary — `capability-authoring-governance.md`

The section name now precisely names the two sides of the ownership boundary (.md text vs .meta.yaml metadata).

## Origin

PO clarification during Schema-First Capability Metadata Redesign interview (Phase 2). PO identified that two orthogonal principles were conflated:
- **Metadata-Text Boundary**: exclusive ownership zones between dual-format representations of the same artifact.
- **Single Authoritative Source**: no redundant storage of derivable data — universally applicable.