### PR TITLE
chore: establish arc42 v9 architecture documentation structure

### DIFF
--- a/doc/arc/01_introduction_and_goals.md
+++ b/doc/arc/01_introduction_and_goals.md
@@ -1,0 +1,30 @@
+# Introduction and Goals
+
+Describes the relevant requirements and the driving forces that software architects and development team must consider.
+These include:
+
+- underlying business goals
+- essential features
+- essential functional requirements
+- quality goals for the architecture
+- relevant stakeholders and their expectations
+
+## Requirements Overview
+
+<!-- Short description of the functional requirements, driving forces, extract (or abstract) of requirements.
+     Link to (hopefully existing) requirements documents (with version number and information where to find it). -->
+
+## Quality Goals
+
+<!-- The top three (max five) quality goals for the architecture whose fulfillment is of highest importance to the major stakeholders.
+     We really mean quality goals for the architecture. Don't confuse them with project goals. They are not necessarily identical.
+     Consider this overview of potential topics (based on the ISO 25010 standard): https://quality.arc42.org -->
+
+## Stakeholders
+
+<!-- Explicit overview of stakeholders of the system, i.e. all person, roles or organizations that:
+     - should know the architecture
+     - have to be convinced of the architecture
+     - have to work with the architecture or with code
+     - need the documentation of the architecture for their work
+     - have to come up with decisions about the system or its development -->

--- a/doc/arc/02_architecture_constraints.md
+++ b/doc/arc/02_architecture_constraints.md
@@ -1,0 +1,6 @@
+# Architecture Constraints
+
+Any requirement that constrains software architects in their freedom of design and implementation decisions or decisions about the development process.
+
+<!-- Simple tables of constraints with explanations.
+     If needed you can subdivide them into technical constraints, organizational and political constraints and conventions. -->

--- a/doc/arc/03_context_and_scope.md
+++ b/doc/arc/03_context_and_scope.md
@@ -1,0 +1,15 @@
+# Context and Scope
+
+Delimits your system (i.e. your scope) from all its communication partners (neighboring systems and users, i.e. the context of your system). It thereby specifies the external interfaces.
+
+If necessary, differentiate the business context (domain specific inputs and outputs) from the technical context (channels, protocols, hardware).
+
+## Business Context
+
+<!-- Specification of all communication partners (users, IT-systems, ...) with explanations of domain specific inputs and outputs or interfaces.
+     Optionally you can add domain specific formats or communication protocols. -->
+
+## Technical Context
+
+<!-- Technical interfaces (channels, transmission media) linking your system to its environment.
+     In addition a mapping of domain specific input/output to the channels, i.e. an explanation which I/O uses which channel. -->

--- a/doc/arc/04_solution_strategy.md
+++ b/doc/arc/04_solution_strategy.md
@@ -1,0 +1,10 @@
+# Solution Strategy
+
+A short summary and explanation of the fundamental decisions and solution strategies that shape system architecture. It includes:
+
+- technology decisions
+- decisions about the top-level decomposition of the system, e.g. usage of an architectural pattern or design pattern
+- decisions on how to achieve key quality goals
+- relevant organizational decisions, e.g. selecting a development process or delegating certain tasks to third parties
+
+<!-- These decisions form the cornerstones for your architecture. They are the foundation for many other detailed decisions or implementation rules. -->

--- a/doc/arc/05_building_block_view.md
+++ b/doc/arc/05_building_block_view.md
@@ -1,0 +1,13 @@
+# Building Block View
+
+The building block view shows the static decomposition of the system into building blocks (modules, components, subsystems, classes, interfaces, packages, libraries, frameworks, layers, partitions, tiers, functions, macros, operations, data structures, ...) as well as their dependencies (relationships, associations, ...).
+
+This view is mandatory for every architecture documentation. In analogy to a house this is the _floor plan_.
+
+## Level 1
+
+<!-- The top level decomposition of the system. This is the white box description of the overall system together with black box descriptions of all contained building blocks. -->
+
+## Level 2
+
+<!-- Zoom into building blocks of Level 1. -->

--- a/doc/arc/06_runtime_view.md
+++ b/doc/arc/06_runtime_view.md
@@ -1,0 +1,10 @@
+# Runtime View
+
+Describes concrete behavior and interactions of the system's building blocks in form of scenarios from the following areas:
+
+- important use cases or features: how do building blocks execute them?
+- interactions at critical external interfaces: how do building blocks cooperate with users and neighboring systems?
+- operation and administration: launch, start-up, stop
+- error and exception scenarios
+
+<!-- Document representative (architecturally relevant) scenarios. Not all of them — only a selection. -->

--- a/doc/arc/07_deployment_view.md
+++ b/doc/arc/07_deployment_view.md
@@ -1,0 +1,8 @@
+# Deployment View
+
+The deployment view describes:
+
+1. Technical infrastructure used to execute your system, with infrastructure elements like geographical locations, environments, computers, processors, channels and net topologies as well as other infrastructure elements.
+2. Mapping of (software) building blocks to that infrastructure elements.
+
+<!-- Especially document a deployment view if your software is executed as distributed system with more than one computer, processor, server or container or when you design and construct your own hardware processors and chips. -->

--- a/doc/arc/08_concepts.md
+++ b/doc/arc/08_concepts.md
@@ -1,0 +1,11 @@
+# Cross-cutting Concepts
+
+This section describes overarching, principal regulations and solution ideas that are relevant in multiple parts of the system. Such concepts are often related to multiple building blocks. They may include many different topics, such as:
+
+- Domain models
+- Architecture and design patterns
+- Rules for using specific technology
+- Principal, often technical decisions of an overarching nature
+- Implementation rules
+
+<!-- Concepts form the basis for conceptual integrity (consistency, homogeneity) of the architecture. Thus, they are an important contribution to achieve inner qualities of your system. -->

--- a/doc/arc/09_architecture_decisions.md
+++ b/doc/arc/09_architecture_decisions.md
@@ -1,0 +1,7 @@
+# Architecture Decisions
+
+Important, expensive, large scale or risky architecture decisions including rationales. With "decisions" we mean selecting one alternative based on given criteria.
+
+<!-- Use your judgement to decide whether an architectural decision should be documented here in this central section or whether you better document it locally (e.g. within the building block view).
+     Avoid redundancy. Refer to section 4, where you already captured the most important decisions of your architecture.
+     See https://docs.arc42.org/section-9/ for further information. -->

--- a/doc/arc/10_quality_requirements.md
+++ b/doc/arc/10_quality_requirements.md
@@ -1,0 +1,15 @@
+# Quality Requirements
+
+This section contains all relevant quality requirements.
+
+The most important of these requirements have already been described in section 1.2 (quality goals), therefore they should only be referenced here. In this section you should also capture quality requirements with lesser importance, which will not create high risks when they are not fully achieved (but might be _nice-to-have_).
+
+## Quality Requirements Overview
+
+<!-- An overview or summary of quality requirements. Can be a table or a quality tree (as defined in ATAM). -->
+
+## Quality Scenarios
+
+<!-- Concretization of (sometimes vague or implicit) quality requirements using (quality) scenarios.
+     These scenarios describe what should happen when a stimulus arrives at the system.
+     See https://quality.arc42.org for inspiration. -->

--- a/doc/arc/11_risks_technical_debts.md
+++ b/doc/arc/11_risks_technical_debts.md
@@ -1,0 +1,6 @@
+# Risks and Technical Debts
+
+A list of identified technical risks or technical debts, ordered by priority.
+
+<!-- "Risk management is project management for grown-ups" (Tim Lister, Atlantic Systems Guild.)
+     Systematic detection and evaluation of risks and technical debts in the architecture, which will be needed by management stakeholders as part of the overall risk analysis and measurement planning. -->

--- a/doc/arc/12_glossary.md
+++ b/doc/arc/12_glossary.md
@@ -1,0 +1,9 @@
+# Glossary
+
+The most important domain and technical terms that stakeholders use when discussing the system.
+
+<!-- You can also see the glossary as source for translations if you work in multi-language teams. -->
+
+| Term | Definition |
+|------|------------|
+| | |

--- a/doc/arc/README.md
+++ b/doc/arc/README.md
@@ -1,0 +1,29 @@
+# ai4X Architecture Documentation
+
+Based on [arc42](https://arc42.org) template version 9.0 (July 2025).
+
+## Sections
+
+| # | Section | File |
+|---|---------|------|
+| 1 | [Introduction and Goals](01_introduction_and_goals.md) | System requirements, quality goals, stakeholders |
+| 2 | [Architecture Constraints](02_architecture_constraints.md) | Technical, organizational, political constraints |
+| 3 | [Context and Scope](03_context_and_scope.md) | Business and technical context |
+| 4 | [Solution Strategy](04_solution_strategy.md) | Fundamental decisions and solution strategies |
+| 5 | [Building Block View](05_building_block_view.md) | Static decomposition of the system |
+| 6 | [Runtime View](06_runtime_view.md) | Behavior and interactions |
+| 7 | [Deployment View](07_deployment_view.md) | Technical infrastructure and mapping |
+| 8 | [Cross-cutting Concepts](08_concepts.md) | Overarching patterns, regulations, concepts |
+| 9 | [Architecture Decisions](09_architecture_decisions.md) | Important architectural decisions with rationale |
+| 10 | [Quality Requirements](10_quality_requirements.md) | Quality scenarios and requirements |
+| 11 | [Risks and Technical Debts](11_risks_technical_debts.md) | Known risks and technical debt |
+| 12 | [Glossary](12_glossary.md) | Domain and technical terms |
+
+## About arc42
+
+arc42, the template for documentation of software and system architecture.
+
+Template Version 9.0-EN (based upon AsciiDoc version), July 2025.
+
+Created, maintained and (C) by Dr. Peter Hruschka, Dr. Gernot Starke and contributors.
+See <https://arc42.org>.


### PR DESCRIPTION
## Summary

Add arc42 v9.0 (July 2025) template structure under `doc/arc/` as GitHub Markdown multi-page format.

### Structure

13 files: README.md (index) + 12 section files following the canonical arc42 numbering:

1. Introduction and Goals
2. Architecture Constraints
3. Context and Scope
4. Solution Strategy
5. Building Block View
6. Runtime View
7. Deployment View
8. Cross-cutting Concepts
9. Architecture Decisions
10. Quality Requirements
11. Risks and Technical Debts
12. Glossary

### Status

Empty structural placeholders with section descriptions from the official template. Content will be filled incrementally — starting with Section 8 (capability metadata schema reference) and Section 9 (ADR from the current metadata redesign interview).

### Pragmatic approach

Only sections with substance get content. No filler, no premature prose.

## Origin

PO directive during F14 (Documentation) decision in the Schema-First Capability Metadata Redesign interview.