### PR TITLE
chore: glossary extraction and workflow.md decomposition

### DIFF
--- a/adm/gdl/dev/protocols/workflow.md
+++ b/adm/gdl/dev/protocols/workflow.md
@@ -148,6 +148,7 @@ The Tech Lead determines in Stage 1 which stages are needed for the current Stor
 9. Missing mandatory artifacts, unresolved contradictions, or unresolved high-severity findings block progression.
 10. When a conditional stage is skipped, its output artifact is marked `n/a` in the conformance record.
 11. When Review B blocks and returns to Implementation, Stages 7–8 re-execute before resubmitting to Review B.
+
 ### Gate Decision Semantics
 
 1. Specialist gate outputs are `blocked` or `conditional-approve`.

--- a/adm/gdl/dev/protocols/workflow.md
+++ b/adm/gdl/dev/protocols/workflow.md
@@ -146,7 +146,8 @@ The Tech Lead determines in Stage 1 which stages are needed for the current Stor
 7. Testing stage must consume Requirements Pack, Architecture Pack (if produced), and Implementation Pack; it must produce a Test Evidence Pack.
 8. Critical Review Pass B must consume Implementation Pack and Test Evidence Pack and produce Review B Findings.
 9. Missing mandatory artifacts, unresolved contradictions, or unresolved high-severity findings block progression.
-10. When a conditional stage is skipped, its output artifact is marked `n/a` in the conformance record.12. When Review B blocks and returns to Implementation, Stages 7–8 re-execute before resubmitting to Review B.
+10. When a conditional stage is skipped, its output artifact is marked `n/a` in the conformance record.
+11. When Review B blocks and returns to Implementation, Stages 7–8 re-execute before resubmitting to Review B.
 ### Gate Decision Semantics
 
 1. Specialist gate outputs are `blocked` or `conditional-approve`.
@@ -155,6 +156,8 @@ The Tech Lead determines in Stage 1 which stages are needed for the current Stor
 ## Governance Glossary
 
 This glossary defines canonical terms for workflow execution, reviews, and onboarding.
+
+> **Planning Terms** and **Qualifier Terms** — see `adm/gdl/glossary.md` for canonical definitions.
 
 ### Gate Terms
 
@@ -203,25 +206,6 @@ This glossary defines canonical terms for workflow execution, reviews, and onboa
 
 3. approved
 - Final acceptance verdict by orchestration only, after all mandatory remediation is closed.
-
-### Planning Terms
-
-1. Idea
-- A vague intent or exploration drafted by the PO in `adm/pbl/`. Temporary.
-
-2. Epic
-- A refined requirement scope with acceptance criteria. Promoted to a GitHub Issue with label `epic`.
-
-3. Story
-- An implementable unit of work within an Epic. GitHub Issue with label `story`, linked to parent Epic.
-
-4. Task
-- An implementation step within a Story. Represented as a checklist within the Story Issue.
-
-### Qualifier Terms
-
-1. Non-trivial
-- A change is non-trivial if it adds or modifies behavior, contracts, boundaries, acceptance criteria, or domain types. Mechanical changes (typo fixes, formatting, comment-only edits) are trivial. When in doubt, treat the change as non-trivial.
 
 ## Session Conformance Check
 

--- a/adm/gdl/glossary.md
+++ b/adm/gdl/glossary.md
@@ -3,6 +3,8 @@
 Canonical term definitions for the ai4X governance layer.
 Terms defined here are the single authoritative source. Other documents reference this file rather than restating definitions.
 
+**Scope:** This file contains reference-safe terms only (Planning Terms, Qualifier Terms). Dispatch-critical terms (Gate Terms, Artifact Terms, Verdict Terms) remain inline at their point of use in `dev/protocols/workflow.md`. See `doc/arc/09_architecture_decisions.md` § ADR-001 for rationale.
+
 ## Planning Terms
 
 1. **Idea**

--- a/adm/gdl/glossary.md
+++ b/adm/gdl/glossary.md
@@ -1,0 +1,23 @@
+# Governance Glossary
+
+Canonical term definitions for the ai4X governance layer.
+Terms defined here are the single authoritative source. Other documents reference this file rather than restating definitions.
+
+## Planning Terms
+
+1. **Idea**
+   - A vague intent or exploration drafted by the PO in `adm/pbl/`. Temporary.
+
+2. **Epic**
+   - A refined requirement scope with acceptance criteria. Promoted to a GitHub Issue with label `epic`.
+
+3. **Story**
+   - An implementable unit of work within an Epic. GitHub Issue with label `story`, linked to parent Epic.
+
+4. **Task**
+   - An implementation step within a Story. Represented as a checklist within the Story Issue.
+
+## Qualifier Terms
+
+1. **Non-trivial**
+   - A change is non-trivial if it adds or modifies behavior, contracts, boundaries, acceptance criteria, or domain types. Mechanical changes (typo fixes, formatting, comment-only edits) are trivial. When in doubt, treat the change as non-trivial.

--- a/adm/gdl/index.yaml
+++ b/adm/gdl/index.yaml
@@ -139,6 +139,14 @@ sections:
     title: Shared Governance
     description: Cross-cutting governance protocols used by both planning and development.
     documents:
+      - path: glossary.md
+        title: Governance Glossary
+        purpose: Define canonical planning and qualifier terms as single authoritative source.
+        priority: must-read
+        depends_on: []
+        audience: all
+        scope: Term definitions referenced by all governance documents
+
       - path: shr/protocols/board-policy.md
         title: Board Policy
         purpose: Define board status transitions, ownership gates, lifecycle diagrams, and label conventions.
@@ -185,7 +193,8 @@ sections:
 # 13. adm/gdl/shr/protocols/board-policy.md — board transitions, ownership gates, labels
 # 14. adm/gdl/pln/protocols/planning-conformance.md — planning conformance enforcement
 # 15. adm/gdl/ops/github-repo-metadata.md — operations (as needed)
-# Terminology reference: see the Governance Glossary section in adm/gdl/dev/protocols/workflow.md for canonical gate, artifact, and verdict terms.
+# Terminology reference: see adm/gdl/glossary.md for planning/qualifier terms;
+#   see the Governance Glossary section in adm/gdl/dev/protocols/workflow.md for gate, artifact, and verdict terms.
 
 # For Specific Tasks
 # ==================
@@ -193,4 +202,5 @@ sections:
 # Planning a feature: read .github/agents/ai4x.agent.md → dev/contracts/* → pln/protocols/workflow.md → shr/protocols/board-policy.md → pln/protocols/planning-conformance.md
 # Setting up repo automation: read .github/agents/ai4x.agent.md → ops/github-repo-metadata.md
 # Onboarding a contributor: read in full order above
-# Workflow terminology alignment: use the Governance Glossary in dev/protocols/workflow.md to avoid gate-term drift.
+# Workflow terminology alignment: use adm/gdl/glossary.md for planning/qualifier terms;
+#   use the Governance Glossary in dev/protocols/workflow.md for gate, artifact, and verdict terms.

--- a/adm/gdl/pln/protocols/workflow.md
+++ b/adm/gdl/pln/protocols/workflow.md
@@ -12,6 +12,8 @@ This document defines the planning workflow for ai4X, following established Scru
 
 ## Work Item Hierarchy
 
+> Canonical term definitions: see `adm/gdl/glossary.md` § Planning Terms.
+
 | Level | What | Who creates | Who approves | GitHub representation |
 |-------|------|-------------|-------------|----------------------|
 | **Idea** | Vague intent, exploration | PO | — | `adm/pbl/*.md` (temporary) |

--- a/adm/gdl/shr/protocols/board-policy.md
+++ b/adm/gdl/shr/protocols/board-policy.md
@@ -42,7 +42,13 @@ Issue intake defines how an Issue reaches Ready. This differs by type.
 | → **Backlog** | Tech Lead | Epic Issue created after PO approval of Requirements Pack (Phase 2 exit gate). |
 | **Backlog → Ready** | PO | Acceptance criteria are complete and testable. PO confirms release for development. Planning conformance check passed (see `adm/gdl/pln/protocols/planning-conformance.md`). |
 
-Epic execution tracking (when all Stories are done) follows the same delivery lifecycle per Story. The Epic itself moves to Done when the PO confirms final acceptance of all ACs across all Stories.
+### Epic Delivery
+
+| Transition | Owner | Prerequisites |
+|------------|-------|---------------|
+| **Ready → In progress** | Tech Lead | First Story of the Epic enters In progress. |
+| **In progress → In review** | Tech Lead | All Stories are Done or In review. Final acceptance pending. |
+| **In review → Done** | PO | PO confirms final acceptance of all Epic ACs across all Stories. |
 
 ### Story Intake
 

--- a/doc/arc/09_architecture_decisions.md
+++ b/doc/arc/09_architecture_decisions.md
@@ -5,3 +5,50 @@ Important, expensive, large scale or risky architecture decisions including rati
 <!-- Use your judgement to decide whether an architectural decision should be documented here in this central section or whether you better document it locally (e.g. within the building block view).
      Avoid redundancy. Refer to section 4, where you already captured the most important decisions of your architecture.
      See https://docs.arc42.org/section-9/ for further information. -->
+
+## ADR-001: Glossary Term Placement — Inline vs. Reference
+
+**Status:** Accepted  
+**Date:** 2026-05-06  
+**Context:** Epic #43 (Agentic Team Optimization)
+
+### Context
+
+The ai4X governance layer defines terms used by AI agents in their operational instructions. These terms appear in documents that VS Code Copilot agents consume as prompt material. The placement of term definitions directly impacts agent compliance behavior.
+
+VS Code only auto-loads two files into an agent's context window: `copilot-instructions.md` (always) and the active `.agent.md` (as modeInstructions). All other files require explicit "Required Reading" instructions — a behavioral hint the model MAY follow, not a guaranteed injection mechanism.
+
+### Decision
+
+Term definitions are split into two categories based on their operational criticality for agent dispatch:
+
+| Category | Placement | Rationale |
+|----------|-----------|-----------|
+| **Gate Terms** (Stage Gate, Progression, Remediation) | Inline in `dev/protocols/workflow.md` | Dispatch-critical. Misinterpretation breaks the stage pipeline. |
+| **Artifact Terms** (Requirements Pack, Architecture Pack, etc.) | Inline in `dev/protocols/workflow.md` | Agents verify artifact presence at gate decisions. Must be in-context. |
+| **Verdict Terms** (blocked, conditional-approve, approved) | Inline in `dev/protocols/workflow.md` | These are the gate output values. Must be unambiguous at point of use. |
+| **Planning Terms** (Idea, Epic, Story, Task) | Reference-only in `adm/gdl/glossary.md` | Consumed primarily by the orchestrator agent, which always loads `workflow.md` and can follow the reference. Not dispatch-critical for specialists. |
+| **Qualifier Terms** (Non-trivial) | Reference-only in `adm/gdl/glossary.md` | Supplementary context. Agents use the term but do not dispatch on its exact definition. |
+
+### Governing Principle
+
+> DEDUPLICATE FACTS (prevent drift); KEEP INSTRUCTIONS explicit (ensure compliance).
+
+- A term that governs agent behavior at the point where it appears is an **instruction** → inline.
+- A term that provides supplementary context is a **fact** → single source in glossary, reference elsewhere.
+
+### Consequences
+
+- `adm/gdl/glossary.md` contains ONLY reference-safe terms (Planning Terms, Qualifier Terms).
+- Gate Terms, Artifact Terms, and Verdict Terms MUST remain inline in `dev/protocols/workflow.md`.
+- If a future dry-run reveals an agent failing to follow a glossary reference, the failing term must be inlined back immediately (fallback rule).
+- New terms must be classified before placement. The classification criterion is: "Does an agent dispatch on this term's exact definition?" If yes → inline. If no → glossary.
+
+### Rejected Alternative
+
+**Full extraction of all terms into `glossary.md` with reference-only usage everywhere.**
+
+Rejected because:
+- Violates the Prompt-Context Design Rule: "Inline actionable constraints at point of use."
+- Under the VS Code injection model, there is no mechanism to guarantee `glossary.md` is in the context window when a specialist agent processes a gate decision.
+- Creates a compliance regression detectable only at runtime.


### PR DESCRIPTION
## Summary

Closes #44 (Story: Glossary extraction and workflow.md decomposition)
Parent Epic: #43 (Agentic Team Optimization)

## Changes

1. **Create `adm/gdl/glossary.md`** — standalone single authoritative source for Planning Terms and Qualifier Terms (AC-2.1)
2. **Replace restated definitions with references** — `dev/protocols/workflow.md` and `pln/protocols/workflow.md` reference glossary instead of restating (AC-2.2)
3. **Routing Table self-contained** — Expert Team Routing + Stage Applicability remain focused, self-contained sections (AC-2.3)
4. **Branching/Commit as distinct section** — confirmed as separate H2 sections (AC-2.4)
5. **Fix numbering error** — Stage Input/Output Contract items 10→12 corrected to 10→11 (AC-2.5)

## Additional Deliverables

- **ADR-001** (`doc/arc/09_architecture_decisions.md`): Documents the inline-vs-reference term placement decision
- **Board-Policy fix** (`adm/gdl/shr/protocols/board-policy.md`): Adds explicit Epic Delivery transitions (Ready → In progress → In review → Done)
- **Markdown fix**: Missing blank line before Gate Decision Semantics heading

## AI Strategy Note (Stage 5)

The AI Strategy agent was consulted for this Story. Key guidance applied:
- Gate/Artifact/Verdict Terms: inline (dispatch-critical for agents)
- Planning/Qualifier Terms: glossary reference (safe for orchestrator)
- Routing Table format preserved as numbered list (complex conditions per entry)

## Review B Verdict

conditional-approve — no blockers. Two low-severity findings resolved in-branch.

## Verification

- `make verify` passes ✓