### PR TITLE
chore: add frontmatter and document circular reference

### DIFF
--- a/adm/gdl/dev/contracts/ai-strategy-quality.md
+++ b/adm/gdl/dev/contracts/ai-strategy-quality.md
@@ -1,3 +1,8 @@
+---
+version: 1.0.0
+last_updated: 2026-05-06
+---
+
 # AI Strategy Quality Contract
 
 ## Purpose

--- a/adm/gdl/dev/contracts/architecture-quality.md
+++ b/adm/gdl/dev/contracts/architecture-quality.md
@@ -1,3 +1,8 @@
+---
+version: 1.0.0
+last_updated: 2026-05-06
+---
+
 # Architecture Quality Contract
 
 ## Purpose

--- a/adm/gdl/dev/contracts/capability-authoring-governance.md
+++ b/adm/gdl/dev/contracts/capability-authoring-governance.md
@@ -3,6 +3,7 @@ child: Contract
 title: Capability Authoring Governance
 scope: ai4x
 version: 0.2.0
+last_updated: 2026-05-06
 status: released
 owner: ai4x-capability-governance
 ---

--- a/adm/gdl/dev/contracts/engineering-quality.md
+++ b/adm/gdl/dev/contracts/engineering-quality.md
@@ -1,3 +1,8 @@
+---
+version: 1.0.0
+last_updated: 2026-05-06
+---
+
 # Engineering Quality Contract
 
 ## Purpose

--- a/adm/gdl/dev/contracts/implementation-quality.md
+++ b/adm/gdl/dev/contracts/implementation-quality.md
@@ -1,3 +1,8 @@
+---
+version: 1.0.0
+last_updated: 2026-05-06
+---
+
 # Implementation Quality Contract
 
 ## Purpose

--- a/adm/gdl/dev/contracts/requirements-quality.md
+++ b/adm/gdl/dev/contracts/requirements-quality.md
@@ -1,3 +1,8 @@
+---
+version: 1.0.0
+last_updated: 2026-05-06
+---
+
 # Requirements Quality Contract
 
 ## Purpose

--- a/adm/gdl/dev/contracts/review-quality.md
+++ b/adm/gdl/dev/contracts/review-quality.md
@@ -1,3 +1,8 @@
+---
+version: 1.0.0
+last_updated: 2026-05-06
+---
+
 # Review Quality Contract
 
 ## Purpose

--- a/adm/gdl/dev/contracts/testing-quality.md
+++ b/adm/gdl/dev/contracts/testing-quality.md
@@ -1,3 +1,8 @@
+---
+version: 1.0.0
+last_updated: 2026-05-06
+---
+
 # Testing Quality Contract
 
 ## Purpose

--- a/adm/gdl/dev/contracts/typescript-quality.md
+++ b/adm/gdl/dev/contracts/typescript-quality.md
@@ -1,3 +1,8 @@
+---
+version: 1.0.0
+last_updated: 2026-05-06
+---
+
 # TypeScript Quality Contract
 
 ## Purpose

--- a/adm/gdl/dev/protocols/capability-sweep.md
+++ b/adm/gdl/dev/protocols/capability-sweep.md
@@ -1,3 +1,8 @@
+---
+version: 1.0.0
+last_updated: 2026-05-06
+---
+
 # Capability Sweep Protocol
 
 ## Purpose

--- a/adm/gdl/dev/protocols/development-conformance-template.md
+++ b/adm/gdl/dev/protocols/development-conformance-template.md
@@ -1,3 +1,8 @@
+---
+version: 1.0.0
+last_updated: 2026-05-06
+---
+
 # Agent Conformance One-Page Template
 
 Use this compact template during active sessions.

--- a/adm/gdl/dev/protocols/development-conformance.md
+++ b/adm/gdl/dev/protocols/development-conformance.md
@@ -1,3 +1,8 @@
+---
+version: 1.0.0
+last_updated: 2026-05-06
+---
+
 # Agent Conformance Contract
 
 ## Purpose

--- a/adm/gdl/dev/protocols/workflow.md
+++ b/adm/gdl/dev/protocols/workflow.md
@@ -1,3 +1,8 @@
+---
+version: 1.0.0
+last_updated: 2026-05-06
+---
+
 # Development Workflow
 
 ## Purpose

--- a/adm/gdl/glossary.md
+++ b/adm/gdl/glossary.md
@@ -1,3 +1,8 @@
+---
+version: 1.0.0
+last_updated: 2026-05-06
+---
+
 # Governance Glossary
 
 Canonical term definitions for the ai4X governance layer.

--- a/adm/gdl/ops/github-repo-metadata.md
+++ b/adm/gdl/ops/github-repo-metadata.md
@@ -1,3 +1,8 @@
+---
+version: 1.0.0
+last_updated: 2026-05-06
+---
+
 # GitHub Repository Metadata Runbook
 
 ## Purpose

--- a/adm/gdl/pln/protocols/planning-conformance.md
+++ b/adm/gdl/pln/protocols/planning-conformance.md
@@ -1,3 +1,8 @@
+---
+version: 1.0.0
+last_updated: 2026-05-06
+---
+
 # Planning Conformance Contract
 
 ## Purpose

--- a/adm/gdl/pln/protocols/workflow.md
+++ b/adm/gdl/pln/protocols/workflow.md
@@ -1,3 +1,8 @@
+---
+version: 1.0.0
+last_updated: 2026-05-06
+---
+
 # Planning Workflow: Idea → Epic → Story → Done
 
 ## Overview
@@ -162,6 +167,8 @@ This document defines the planning workflow for ai4X, following established Scru
 | **Tracking board** | GitHub Project `#3` ([link](https://github.com/users/normenmueller/projects/3)). All Epics, Stories, and standalone Issues must be tracked there. Private visibility. |
 
 Board transitions, ownership gates, and label definitions: see `adm/gdl/shr/protocols/board-policy.md`.
+
+> **Note**: Mutual reference — `board-policy.md` references this document for phase definitions. Neither is subordinate; they are complementary protocols with distinct scope (planning lifecycle vs. board mechanics).
 
 ## Visual Flow
 

--- a/adm/gdl/shr/protocols/board-policy.md
+++ b/adm/gdl/shr/protocols/board-policy.md
@@ -1,3 +1,8 @@
+---
+version: 1.0.0
+last_updated: 2026-05-06
+---
+
 # Board Policy
 
 ## Purpose
@@ -88,5 +93,7 @@ Additional labels (optional but recommended):
 ## References
 
 - `adm/gdl/pln/protocols/workflow.md` — Phase definitions and completion checklists.
+
+> **Note**: Mutual reference — `pln/protocols/workflow.md` references this document for board transitions. Neither is subordinate; they are complementary protocols with distinct scope (planning lifecycle vs. board mechanics).
 - `adm/gdl/pln/protocols/planning-conformance.md` — Planning conformance check.
 - `adm/gdl/dev/protocols/workflow.md` — 10-stage development workflow (Story execution).


### PR DESCRIPTION
## Story #49 — Documentation Hygiene

Closes #49 (Epic #43, Story S6)

### Changes

**AC-6.1**: Added YAML frontmatter (`version: 1.0.0`, `last_updated: 2026-05-06`) to all 18 normative governance docs under `adm/gdl/`.

**AC-6.2**: H3 heading depth assessed and tolerated — sub-sections (phases, gate types) are semantically correct hierarchy. No H4+ exists. AI Strategy expert endorses: LLMs parse heading hierarchy natively, flat H2 would be worse.

**AC-6.3**: Mutual reference between `board-policy.md` and `pln/workflow.md` documented with explicit blockquote note in both files: neither is subordinate, they are complementary protocols with distinct scope.

### AI Strategy Review

All three decisions endorsed by AI Strategy specialist (no agent impact concerns, negligible token cost).

### Validation

`make verify` passes.