### PR TITLE
docs: add architecture terms to governance glossary

### DIFF
--- a/adm/gdl/README.md
+++ b/adm/gdl/README.md
@@ -9,7 +9,7 @@ This directory contains normative guidance documents for ai4X development, opera
 | **dev/** | Development standards, code quality, workflow | `contracts/engineering-quality.md`, `contracts/typescript-quality.md`, `protocols/development-conformance.md`, `protocols/development-conformance-template.md`, `protocols/workflow.md` |
 | **pln/** | Planning governance, backlog management, issue promotion | `protocols/workflow.md`, `protocols/planning-conformance.md` |
 | **shr/** | Cross-cutting governance (planning + development) | `protocols/board-policy.md` |
-| **glossary.md** | Canonical term definitions (Planning Terms, Qualifier Terms) | `glossary.md` |
+| **glossary.md** | Canonical term definitions (Planning Terms, Qualifier Terms, Architecture Terms) | `glossary.md` |
 
 ## Reading Guide
 

--- a/adm/gdl/glossary.md
+++ b/adm/gdl/glossary.md
@@ -32,7 +32,7 @@ Terms defined here are the single authoritative source. Other documents referenc
 ## Architecture Terms
 
 1. **Agent Host**
-   - A runtime environment that executes agentic AI agents. Examples: VS Code with GitHub Copilot, Codex CLI, Claude Code. ai4X is agent-host-agnostic — it declares agents independently and materializes them for a specific host at activation time.
+   - A runtime environment that hosts and executes AI agents. Examples: VS Code with GitHub Copilot, Codex CLI, Claude Code. ai4X is agent-host-agnostic — it declares agents independently and materializes them for a specific host at activation time.
 
 2. **Cognitive Capability Composition (CCC)** *(Design Target)*
    - A declarative specification that defines an agent by composing revision-safe references to cognitive capabilities from the ai4X corpus (`dev/cap/`). A CCC declares *what* an agent knows and *how* it reasons — not *where* it runs. CCCs are the input to materialization.
@@ -41,7 +41,7 @@ Terms defined here are the single authoritative source. Other documents referenc
    - A reusable, abstract collaboration pattern that defines roles and coordination structure for a team of agents — independent of which concrete agents fill those roles. Examples: leader–specialists, swarm, pipeline. Topologies are value objects: "leader + n specialists" is the same pattern regardless of the agents involved.
 
 4. **Materialization** *(Design Target)*
-   - The deterministic transformation of a host-agnostic agent declaration (CCC) into the format required by a specific Agent Host. `ai4x spawn --target <agent-host>` performs this transformation. Materialization is a pure function: same declaration and target produce the same output.
+   - The deterministic transformation of a host-agnostic agent declaration (CCC) into the format required by a specific Agent Host. Materialization is the first step of the `spawn` lifecycle — it produces the host-specific artifacts that `spawn` then activates. Same declaration and same target always produce the same output.
 
 5. **Team Declaration** *(Design Target)*
    - The aggregate output of `ai4x curate`. Binds a collaboration topology to a concrete set of agents with explicit role assignments. A Team Declaration is the complete, reproducible specification of an agentic team — topology, agents, and their binding — ready for materialization.

--- a/adm/gdl/glossary.md
+++ b/adm/gdl/glossary.md
@@ -1,6 +1,6 @@
 ---
-version: 1.0.0
-last_updated: 2026-05-06
+version: 1.1.0
+last_updated: 2026-05-08
 ---
 
 # Governance Glossary
@@ -8,7 +8,7 @@ last_updated: 2026-05-06
 Canonical term definitions for the ai4X governance layer.
 Terms defined here are the single authoritative source. Other documents reference this file rather than restating definitions.
 
-**Scope:** This file contains reference-safe terms only (Planning Terms, Qualifier Terms). Dispatch-critical terms (Gate Terms, Artifact Terms, Verdict Terms) remain inline at their point of use in `dev/protocols/workflow.md`. See `doc/arc/09_architecture_decisions.md` § ADR-001 for rationale.
+**Scope:** This file contains reference-safe terms only (Planning Terms, Qualifier Terms, Architecture Terms). Dispatch-critical terms (Gate Terms, Artifact Terms, Verdict Terms) remain inline at their point of use in `dev/protocols/workflow.md`. See `doc/arc/09_architecture_decisions.md` § ADR-001 for rationale.
 
 ## Planning Terms
 
@@ -28,3 +28,20 @@ Terms defined here are the single authoritative source. Other documents referenc
 
 1. **Non-trivial**
    - A change is non-trivial if it adds or modifies behavior, contracts, boundaries, acceptance criteria, or domain types. Mechanical changes (typo fixes, formatting, comment-only edits) are trivial. When in doubt, treat the change as non-trivial.
+
+## Architecture Terms
+
+1. **Agent Host**
+   - A runtime environment that executes agentic AI agents. Examples: VS Code with GitHub Copilot, Codex CLI, Claude Code. ai4X is agent-host-agnostic — it declares agents independently and materializes them for a specific host at activation time.
+
+2. **Cognitive Capability Composition (CCC)** *(Design Target)*
+   - A declarative specification that defines an agent by composing revision-safe references to cognitive capabilities from the ai4X corpus (`dev/cap/`). A CCC declares *what* an agent knows and *how* it reasons — not *where* it runs. CCCs are the input to materialization.
+
+3. **Collaboration Topology** *(Design Target)*
+   - A reusable, abstract collaboration pattern that defines roles and coordination structure for a team of agents — independent of which concrete agents fill those roles. Examples: leader–specialists, swarm, pipeline. Topologies are value objects: "leader + n specialists" is the same pattern regardless of the agents involved.
+
+4. **Materialization** *(Design Target)*
+   - The deterministic transformation of a host-agnostic agent declaration (CCC) into the format required by a specific Agent Host. `ai4x spawn --target <agent-host>` performs this transformation. Materialization is a pure function: same declaration and target produce the same output.
+
+5. **Team Declaration** *(Design Target)*
+   - The aggregate output of `ai4x curate`. Binds a collaboration topology to a concrete set of agents with explicit role assignments. A Team Declaration is the complete, reproducible specification of an agentic team — topology, agents, and their binding — ready for materialization.

--- a/doc/arc/09_architecture_decisions.md
+++ b/doc/arc/09_architecture_decisions.md
@@ -39,7 +39,7 @@ Term definitions are split into two categories based on their operational critic
 
 ### Consequences
 
-- `adm/gdl/glossary.md` contains ONLY reference-safe terms (Planning Terms, Qualifier Terms).
+- `adm/gdl/glossary.md` contains ONLY reference-safe terms (Planning Terms, Qualifier Terms, Architecture Terms).
 - Gate Terms, Artifact Terms, and Verdict Terms MUST remain inline in `dev/protocols/workflow.md`.
 - If a future dry-run reveals an agent failing to follow a glossary reference, the failing term must be inlined back immediately (fallback rule).
 - New terms must be classified before placement. The classification criterion is: "Does an agent dispatch on this term's exact definition?" If yes → inline. If no → glossary.


### PR DESCRIPTION
## Story

closes #62 (S3: Glossary Architecture Terms)
Parent Epic: #59

## Changes

Adds an **Architecture Terms** section to `adm/gdl/glossary.md` with five canonical definitions:

| Term | Design Target? |
|------|---------------|
| Agent Host | No (factual) |
| Cognitive Capability Composition (CCC) | Yes |
| Collaboration Topology | Yes |
| Materialization | Yes |
| Team Declaration | Yes |

### Review remediation
- Fixed cross-document enumeration drift in ADR-001 and `adm/gdl/README.md`
- Clarified materialization as first step of spawn lifecycle (distinct from activation)
- Fixed tautological phrasing

## AC Coverage

| AC | Status |
|----|--------|
| AC-10: Architecture Terms section | ✓ |
| AC-11: Five terms defined | ✓ |
| AC-12: Design Target qualifier | ✓ |
| AC-13: No contradictions | ✓ |