### PR TITLE
chore: align repository metadata casing

### DIFF
--- a/utl/gh/repo-metadata.yaml
+++ b/utl/gh/repo-metadata.yaml
@@ -1,5 +1,5 @@
 version: 0.1.0
-repo: ai4x
+repo: ai4X
 about: "Operating model for fit-for-purpose, consistent agent curation and explicit runtime activation"
 topics:
   - ai


### PR DESCRIPTION
## Summary

- change the authoritative repository metadata name from `ai4x` to `ai4X`
- preserve the existing exact, case-sensitive verifier behavior
- unblock repository verification for unrelated pull requests, including #112

## Root cause

`utl/gh/repo-metadata.yaml` used lowercase `ai4x`, while the Git remote and GitHub repository are named `ai4X`. The exact metadata verifier therefore rejected every verification run before other checks could complete.

## Scope

One value in one file:

```diff
-repo: ai4x
+repo: ai4X
```

No About, Topics, remote metadata, product, governance, workflow, verifier, or PR #112 content changed.

## Verification

- pre-change `--check-local`: expected RED on the exact casing mismatch
- pre-change `make verify`: expected RED on the same mismatch
- `bash ./utl/gh/repo-metadata.sh --check-local`: pass
- authenticated `bash ./utl/gh/repo-metadata.sh --check`: pass
- remote About and Topics unchanged before/after
- `make verify`: pass
- `git diff --check`: pass
- exact scope: one insertion and one deletion in `utl/gh/repo-metadata.yaml`
- Stage 7 Implementation Pack: https://github.com/normenmueller/ai4X/issues/113#issuecomment-5241894020
- Stage 8 Test Evidence Pack: https://github.com/normenmueller/ai4X/issues/113#issuecomment-5241954710
- Stage 9 independent Review B: https://github.com/normenmueller/ai4X/issues/113#issuecomment-5242024580
- Stage 10 conformance: https://github.com/normenmueller/ai4X/issues/113#issuecomment-5242052177

## Observation

The repository currently has no `make doctor` target although the workflow completion gate names it. This baseline is unrelated to this PR and is recorded in the Stage-10 conformance; no passing `make doctor` claim is made.

Closes #113
