### PR TITLE
fix: accept initial Base Authorization lineage

### DIFF
--- a/utl/gh/RUNBOOK.md
+++ b/utl/gh/RUNBOOK.md
@@ -122,7 +122,9 @@ The closed PO-reserved constraint vocabulary is `base-replacement`,
 `no-branch-deletion`, and `no-destructive-rewrite`. Issue #120 must carry the
 complete set. `baseAuthorization.lineage` is the sole authority history: its
 first entry is the exact initial revision, approver, and base OID with a null
-replacement approval. Every successor is contiguous and anchors the exact
+replacement approval. This one-entry initial lineage is valid for every work
+item, including #120; #120 still requires the complete reservation set above.
+Every successor is contiguous and anchors the exact
 predecessor revision, approver, OID, and canonical authority digest. It also
 records `poApprover`, `poAuthority` as `product-owner`, a renewed PO approval
 revision, both preservation flags as `true`, and

--- a/utl/gh/branch-scope.mjs
+++ b/utl/gh/branch-scope.mjs
@@ -624,12 +624,6 @@ function validateBaseLineage(base, constraints) {
       "replacement PO-reserved constraints",
     );
   }
-  if (base.workItem === "#120" && normalized.length < 2) {
-    fail(
-      "approval_missing_or_stale",
-      "#120 is a replacement recovery and must retain its preceding Base Authorization anchor",
-    );
-  }
   if (Object.hasOwn(base, "replacement")) {
     fail("invalid_input", "baseAuthorization.replacement is obsolete; use the sole lineage authority");
   }

--- a/utl/gh/branch-scope.test.mjs
+++ b/utl/gh/branch-scope.test.mjs
@@ -1037,9 +1037,9 @@ test("T-14/T-15 failures are non-mutating and deterministic", () => {
   );
 });
 
-test("T-16/T-17 mutation suite enforces #120 authority and non-destructive recovery", () => {
-  const baseOid = "1".repeat(40);
-  const headOid = "2".repeat(40);
+test("T-16/T-17 accepts initial #120 authority and enforces non-destructive recovery", () => {
+  const baseOid = "b2c6ca96930def7477f91f648b8f85e6f24275b8";
+  const headOid = "d51644be2c5370433bdc723af4263e977f68302a";
   const replacementBaseOid = "4".repeat(40);
   const initial = intentFor({ baseOid }, headOid, [
     { operation: "add", path: "evidence.txt" },
@@ -1047,8 +1047,47 @@ test("T-16/T-17 mutation suite enforces #120 authority and non-destructive recov
   initial.baseAuthorization.workItem = "#120";
   initial.readyAuthority.workItem = "#120";
   initial.publicationIntent.workItem = "#120";
+  initial.readyAuthority.revision = "5258296515";
+  initial.baseAuthorization.revision = "BA-120-01";
+  initial.baseAuthorization.targetRepository = "normenmueller/ai4X";
+  initial.baseAuthorization.lineage[0].revision = "BA-120-01";
   initial.baseAuthorization.poReservedConstraints = [...PO_RESERVED_CONSTRAINTS];
-  expectFailure(() => validateIntent(initial), "approval_missing_or_stale");
+  initial.publicationIntent.revision = "PI-120-01";
+  initial.publicationIntent.baseAuthorizationRevision = "BA-120-01";
+  const checkedInitial = validateIntent(structuredClone(initial));
+  assert.equal(checkedInitial.baseAuthorization.lineage.length, 1);
+  assert.equal(checkedInitial.baseAuthorization.lineage[0].replacementApproval, null);
+  assert.deepEqual(
+    checkedInitial.baseAuthorization.poReservedConstraints,
+    [...PO_RESERVED_CONSTRAINTS].sort((left, right) =>
+      Buffer.compare(Buffer.from(left), Buffer.from(right)),
+    ),
+  );
+  const incompleteInitial = structuredClone(initial);
+  incompleteInitial.baseAuthorization.poReservedConstraints = ["base-replacement"];
+  expectFailure(() => validateIntent(incompleteInitial), "approval_missing_or_stale");
+  const falseInitialReplacement = structuredClone(initial);
+  falseInitialReplacement.baseAuthorization.lineage[0].replacementApproval = {};
+  expectFailure(() => validateIntent(falseInitialReplacement), "approval_missing_or_stale");
+
+  const localFixture = createFixture();
+  const localHeadOid = commitFile(localFixture);
+  const localInitial = intentFor(localFixture, localHeadOid, [
+    { operation: "add", path: "feature.txt" },
+  ]);
+  localInitial.baseAuthorization.workItem = "#120";
+  localInitial.readyAuthority.workItem = "#120";
+  localInitial.publicationIntent.workItem = "#120";
+  localInitial.baseAuthorization.poReservedConstraints = [...PO_RESERVED_CONSTRAINTS];
+  const localProof = verifyLocal(localFixture.repo, localInitial);
+  assert.equal(localProof.approvedBaseOid, localFixture.baseOid);
+  assert.equal(localProof.verifiedHeadOid, localHeadOid);
+  assert.deepEqual(localProof.actual.commits, [localHeadOid]);
+  assert.deepEqual(localProof.actual.primitiveRecords, [
+    { operation: "add", path: "feature.txt" },
+  ]);
+  assert.deepEqual(localProof.cleanliness, { index: true, worktree: true });
+  assert.equal(localProof.remoteBinding.repository, FIXTURE_REPOSITORY);
 
   const intent = structuredClone(initial);
   const priorAuthority = intent.baseAuthorization.lineage[0];
@@ -1137,17 +1176,12 @@ test("T-16/T-17 mutation suite enforces #120 authority and non-destructive recov
   const replacement = structuredClone(intent);
   validateIntent(replacement);
 
-  const omittedLineage = structuredClone(replacement);
-  omittedLineage.baseAuthorization.lineage = [
-    {
-      sequence: 1,
-      revision: "base-2",
-      approver: "gertrud-ai4x",
-      baseOid: replacementBaseOid,
-      replacementApproval: null,
-    },
-  ];
-  expectFailure(() => validateIntent(omittedLineage), "approval_missing_or_stale");
+  const omittedPredecessor = structuredClone(replacement);
+  omittedPredecessor.baseAuthorization.lineage.shift();
+  expectFailure(() => validateIntent(omittedPredecessor), "approval_missing_or_stale");
+  const reorderedLineage = structuredClone(replacement);
+  reorderedLineage.baseAuthorization.lineage.reverse();
+  expectFailure(() => validateIntent(reorderedLineage), "approval_missing_or_stale");
 
   for (const field of ["preserveOriginalBranch", "preserveOriginalPullRequest"]) {
     const mutant = structuredClone(replacement);
@@ -1162,6 +1196,19 @@ test("T-16/T-17 mutation suite enforces #120 authority and non-destructive recov
   authorityMutant.baseAuthorization.lineage[1].replacementApproval.previousApprover =
     "someone-else";
   expectFailure(() => validateIntent(authorityMutant), "approval_missing_or_stale");
+  const successorApproverMutant = structuredClone(replacement);
+  successorApproverMutant.baseAuthorization.lineage[1].approver = "someone-else";
+  successorApproverMutant.baseAuthorization.approver = "someone-else";
+  expectFailure(() => validateIntent(successorApproverMutant), "approval_missing_or_stale");
+  const repeatedBaseMutant = structuredClone(replacement);
+  repeatedBaseMutant.baseAuthorization.lineage[1].baseOid = baseOid;
+  repeatedBaseMutant.baseAuthorization.baseOid = baseOid;
+  expectFailure(() => validateIntent(repeatedBaseMutant), "approval_missing_or_stale");
+  const repeatedRevisionMutant = structuredClone(replacement);
+  repeatedRevisionMutant.baseAuthorization.lineage[1].revision = "BA-120-01";
+  repeatedRevisionMutant.baseAuthorization.revision = "BA-120-01";
+  repeatedRevisionMutant.publicationIntent.baseAuthorizationRevision = "BA-120-01";
+  expectFailure(() => validateIntent(repeatedRevisionMutant), "approval_missing_or_stale");
   const poMutant = structuredClone(replacement);
   poMutant.baseAuthorization.lineage[1].replacementApproval.poAuthority = "tech-lead";
   expectFailure(() => validateIntent(poMutant), "approval_missing_or_stale");
@@ -1172,6 +1219,9 @@ test("T-16/T-17 mutation suite enforces #120 authority and non-destructive recov
     (value) =>
       (value.baseAuthorization.lineage[1].replacementApproval.previousAuthorityDigest =
         "6".repeat(64)),
+    (value) =>
+      (value.baseAuthorization.lineage[1].replacementApproval.previousRevision = "base-0"),
+    (value) => (value.baseAuthorization.lineage[1].replacementApproval.poApprover = ""),
     (value) => delete value.baseAuthorization.lineage[1].replacementApproval.poApprovalRevision,
     (value) => (value.baseAuthorization.lineage[1].sequence = 3),
   ]) {


### PR DESCRIPTION
## Summary

- accept a valid one-entry initial Base Authorization lineage for every work item, including #120
- retain #120's complete closed PO-reserved constraint set
- retain strict, digest-bound predecessor, PO, preservation, and non-destructive checks for genuine replacements
- expand deterministic regression coverage and clarify the Runbook boundary

## Why

The verifier unconditionally treated every #120 authority as an existing replacement and therefore demanded a fabricated predecessor even for its first published Base Authorization. This contradicted the accepted #118 contract and blocked #120 despite a correct base, commit, delta, cleanliness, and remote binding.

The fix uses the existing structural distinction: lineage entry zero is initial; every later entry is a replacement. No new flag or authority source is introduced.

## Impact

- fixes the blocking #120 publication preflight
- changes no #120 artifact, commit, intent, or branch
- introduces no dependency, IO, persistent state, fallback, or runtime complexity
- does not weaken Ready, Publication Intent, exact-scope, remote-binding, GitHub reconciliation, or recovery controls

## Verification

- focused branch-scope suite: 38/38 pass
- independent authority matrix: 26/26 expected outcomes plus repeated-predecessor supplement
- `make verify`: pass
- `git diff --check`: pass
- exact scope: three modified files
- real preserved #120 intent in isolation: pass, with base/merge-base `b2c6ca...`, HEAD `d51644be...`, 1/1 commit, 31/31 additions, clean state, and exact GitHub binding
- #120 branch remains unchanged at `d51644be2c5370433bdc723af4263e977f68302a`

## Evidence

- Stage 7 Implementation Pack: https://github.com/normenmueller/ai4X/issues/125#issuecomment-5263646802
- Stage 8 Test Evidence Pack: https://github.com/normenmueller/ai4X/issues/125#issuecomment-5263814303
- independent Review B: https://github.com/normenmueller/ai4X/issues/125#issuecomment-5264100908
- Stage 10 Conformance: https://github.com/normenmueller/ai4X/issues/125#issuecomment-5264145306
- Publication Intent `PI-125-01`: https://github.com/normenmueller/ai4X/issues/125#issuecomment-5264160068

## Residual risk

The intent JSON remains a trusted projection of canonical GitHub Issue authority. The verifier proves internal projection integrity and proof binding; it does not independently authenticate omitted GitHub history. This is the accepted #118 trust boundary, not a new claim of this fix.

Closes #125
