### PR TITLE
Fix fenced planning-example detection

### DIFF
--- a/utl/gh/planning-contract.mjs
+++ b/utl/gh/planning-contract.mjs
@@ -218,7 +218,19 @@ function stageTwo(input) {
 }
 
 function sectionBodies(body, heading) {
-  const lines = body.replaceAll("\r\n", "\n").split("\n");
+  const sourceLines = body.replaceAll("\r\n", "\n").split("\n");
+  const lines = [];
+  let fence = null;
+  for (const line of sourceLines) {
+    const marker = line.match(/^ {0,3}(`{3,}|~{3,})/u)?.[1];
+    if (fence === null) {
+      if (marker !== undefined) fence = { character: marker[0], length: marker.length };
+      else lines.push(line);
+      continue;
+    }
+    const closing = line.match(/^ {0,3}(`{3,}|~{3,})[ \t]*$/u)?.[1];
+    if (closing !== undefined && closing[0] === fence.character && closing.length >= fence.length) fence = null;
+  }
   const sections = [];
   for (let index = 0; index < lines.length; index += 1) {
     if (lines[index] !== heading) continue;

--- a/utl/gh/planning-contract.mjs
+++ b/utl/gh/planning-contract.mjs
@@ -218,13 +218,15 @@ function stageTwo(input) {
 }
 
 function sectionBodies(body, heading) {
-  const sourceLines = body.replaceAll("\r\n", "\n").split("\n");
+  const sourceLines = body.split(/\r\n?|\n/u);
   const lines = [];
   let fence = null;
   for (const line of sourceLines) {
-    const marker = line.match(/^ {0,3}(`{3,}|~{3,})/u)?.[1];
+    const opening = line.match(/^ {0,3}(`{3,}|~{3,})/u);
+    const marker = opening?.[1];
+    const info = opening === null ? undefined : line.slice(opening[0].length);
     if (fence === null) {
-      if (marker !== undefined) fence = { character: marker[0], length: marker.length };
+      if (marker !== undefined && (marker[0] !== "`" || !info.includes("`"))) fence = { character: marker[0], length: marker.length };
       else lines.push(line);
       continue;
     }

--- a/utl/gh/planning-contract.test.mjs
+++ b/utl/gh/planning-contract.test.mjs
@@ -391,6 +391,35 @@ test("all non-Epic kinds accept only their applicable exact Plan-bound states", 
   diagnosticOf(unknownOrigin, "PAUSE_VALUE_UNSUPPORTED");
 });
 
+test("headings and fact-shaped prose inside fenced examples are not authoritative sections", () => {
+  const documentedStandalone = standalone();
+  documentedStandalone.issue.body = [
+    "A Requirements Pack may document the conditional form:",
+    "",
+    "```markdown",
+    "## Pause facts",
+    "",
+    "- Paused from: In progress",
+    "- Pause reason: example only",
+    "- Resume condition: example only",
+    "```",
+  ].join("\n");
+  setStatus(documentedStandalone, "In progress");
+  assertPass(documentedStandalone, "plan-status-only");
+
+  const documentedEpic = epicAt("Refinement");
+  documentedEpic.issue.body = [
+    "~~~markdown",
+    "## Epic gate facts",
+    "",
+    "- Requirements refinement: not started",
+    "~~~",
+    "",
+    documentedEpic.issue.body,
+  ].join("\n");
+  assertPass(documentedEpic, "epic-contract-consistency");
+});
+
 test("all 12 unequal runtime/expected kind substitutions fail before dispatch", () => {
   for (const expectedKind of KINDS) {
     for (const runtimeKind of KINDS) {

--- a/utl/gh/planning-contract.test.mjs
+++ b/utl/gh/planning-contract.test.mjs
@@ -418,6 +418,48 @@ test("headings and fact-shaped prose inside fenced examples are not authoritativ
     documentedEpic.issue.body,
   ].join("\n");
   assertPass(documentedEpic, "epic-contract-consistency");
+
+  const invalidBacktickInfo = epicAt("Refinement");
+  invalidBacktickInfo.issue.body += [
+    "",
+    "```markdown`invalid",
+    "ordinary prose because the backtick info string is invalid",
+    "",
+    "## Pause facts",
+    "",
+    "- Paused from: Refinement",
+    "- Pause reason: stale authoritative facts",
+    "- Resume condition: stale authoritative facts",
+    "```",
+  ].join("\n");
+  diagnosticOf(invalidBacktickInfo, "PAUSE_STALE");
+
+  for (const body of [
+    ["````markdown", "```", "## Pause facts", "```", "````"],
+    ["~~~markdown`allowed", "## Pause facts", "~~~"],
+    ["```markdown", "~~~", "## Pause facts"],
+    ["````markdown", "```", "## Pause facts"],
+  ]) {
+    const fencedNearMiss = standalone();
+    fencedNearMiss.issue.body = body.join("\n");
+    setStatus(fencedNearMiss, "In progress");
+    assertPass(fencedNearMiss, "plan-status-only");
+  }
+
+  const crOnlyStalePause = epicAt("Refinement");
+  crOnlyStalePause.issue.body += "\r## Pause facts\r\r- Paused from: Refinement\r- Pause reason: stale authoritative facts\r- Resume condition: stale authoritative facts\r";
+  diagnosticOf(crOnlyStalePause, "PAUSE_STALE");
+
+  for (const separator of ["\u2028", "\u2029"]) {
+    const unicodeInfo = standalone();
+    unicodeInfo.issue.body = [
+      `\`\`\`markdown${separator}metadata`,
+      "## Pause facts",
+      "```",
+    ].join("\n");
+    setStatus(unicodeInfo, "In progress");
+    assertPass(unicodeInfo, "plan-status-only");
+  }
 });
 
 test("all 12 unequal runtime/expected kind substitutions fail before dispatch", () => {


### PR DESCRIPTION
## Summary

- ignore fenced Markdown examples when discovering authoritative planning sections
- enforce CommonMark-compatible fence opener, closer, and line-ending behavior
- cover valid and adversarial `Pause facts` / `Epic gate facts` examples

## Why

The live #109 Requirements Pack documents the Pause block inside a Markdown fence. The original scanner mistook that example for live facts and would reject #109 itself. Independent review then found malformed fence and line-boundary cases that could hide authoritative facts. This bounded correction closes both self-exclusion and fail-open paths.

## Scope

- two modified files
- two commits on exact `trunk` base `113f4f4f27a6c32924d5cbfd82516ea71d26b620`
- no lifecycle semantics, diagnostic registry, provider adapter, Issue, or Project mutation

## Validation

- focused lifecycle tests: 47/47 passed
- `make verify`: passed; lifecycle aggregate 62/62
- activation preview verifier: 12/12 passed on the initial candidate; final activation Plan remains post-merge gated
- `git diff --check`: passed
- finding-bounded independent re-review: finding-free; publication recommended

Follow-up for #109; Ready-for-review, merge, and activation remain separately gated.
