### PR TITLE
fix: handle complete project field-value closure

### DIFF
--- a/utl/gh/RUNBOOK.md
+++ b/utl/gh/RUNBOOK.md
@@ -265,9 +265,10 @@ never accepted on argv, read from a file, or emitted.
 
 1. Run live verification before and after every governed planning transition
    and preserve the canonical JSON result digest/result as transition evidence.
-2. Exhaust every observed Project item, field, and option page. Identity,
-   accessibility, uniqueness, closure limits, and start/end stability fail
-   closed with distinct diagnostics.
+2. Exhaust every observed Project-item, Project-field, item-field-value,
+   User-member, and Label-member connection at both observation endpoints.
+   Identity, accessibility, supported value variants, uniqueness, closure
+   limits, and start/end stability fail closed with redacted diagnostics.
 3. Never treat a Plan digest or approval-reference string as proof of PO
    approval. The operator independently verifies the exact approval evidence.
 4. Never convert validator success into a command or authority decision. The

--- a/utl/gh/planning-github-observer.mjs
+++ b/utl/gh/planning-github-observer.mjs
@@ -1,14 +1,40 @@
-import { fingerprintObservation, providerDiagnostic } from "./planning-contract.mjs";
+import { canonicalJson, fingerprintObservation, providerDiagnostic } from "./planning-contract.mjs";
+
+const FIELD_VALUE_SELECTION = `
+  __typename
+  ... on ProjectV2ItemFieldUserValue {
+    field { ... on ProjectV2FieldCommon { id } }
+    users(first: $pageSize) { nodes { id } pageInfo { hasNextPage endCursor } }
+  }
+  ... on ProjectV2ItemFieldRepositoryValue {
+    field { ... on ProjectV2FieldCommon { id } }
+    repository { id }
+  }
+  ... on ProjectV2ItemFieldLabelValue {
+    field { ... on ProjectV2FieldCommon { id } }
+    labels(first: $pageSize) { nodes { id } pageInfo { hasNextPage endCursor } }
+  }
+  ... on ProjectV2ItemFieldTextValue {
+    id
+    field { ... on ProjectV2FieldCommon { id } }
+    text
+  }
+  ... on ProjectV2ItemFieldSingleSelectValue {
+    id
+    field { ... on ProjectV2FieldCommon { id } }
+    name
+    optionId
+  }`;
 
 export const QUERY_DOCUMENTS = Object.freeze({
   start: `query PlanningObservationStart($repositoryId: ID!, $issueId: ID!, $projectId: ID!, $itemId: ID!, $statusFieldId: ID!, $pageSize: Int!) {
-    repository: node(id: $repositoryId) { id ... on Repository { nameWithOwner } }
+    repository: node(id: $repositoryId) { __typename id ... on Repository { nameWithOwner } }
     issue: node(id: $issueId) { id ... on Issue { number state body updatedAt } }
     project: node(id: $projectId) { id ... on ProjectV2 {
       items(first: $pageSize) { nodes { id content { __typename ... on Issue { id } ... on PullRequest { id } ... on DraftIssue { id } } } pageInfo { hasNextPage endCursor } }
       fields(first: $pageSize) { nodes { ... on ProjectV2FieldCommon { id name } ... on ProjectV2SingleSelectField { options { id name color description } } } pageInfo { hasNextPage endCursor } }
     } }
-    item: node(id: $itemId) { id ... on ProjectV2Item { content { __typename ... on Issue { id } } fieldValues(first: $pageSize) { nodes { __typename ... on ProjectV2ItemFieldValueCommon { id field { ... on ProjectV2FieldCommon { id } } } ... on ProjectV2ItemFieldSingleSelectValue { name optionId } } pageInfo { hasNextPage endCursor } } } }
+    item: node(id: $itemId) { id ... on ProjectV2Item { content { __typename ... on Issue { id } } fieldValues(first: $pageSize) { edges { cursor node { ${FIELD_VALUE_SELECTION} } } pageInfo { hasNextPage endCursor } } } }
     statusField: node(id: $statusFieldId) { id ... on ProjectV2SingleSelectField { name options { id name color description } } }
   }`,
   items: `query PlanningObservationItems($projectId: ID!, $cursor: String!, $pageSize: Int!) {
@@ -18,21 +44,27 @@ export const QUERY_DOCUMENTS = Object.freeze({
     project: node(id: $projectId) { ... on ProjectV2 { fields(first: $pageSize, after: $cursor) { nodes { ... on ProjectV2FieldCommon { id name } ... on ProjectV2SingleSelectField { options { id name color description } } } pageInfo { hasNextPage endCursor } } } }
   }`,
   values: `query PlanningObservationValues($itemId: ID!, $cursor: String!, $pageSize: Int!) {
-    item: node(id: $itemId) { ... on ProjectV2Item { fieldValues(first: $pageSize, after: $cursor) { nodes { __typename ... on ProjectV2ItemFieldValueCommon { id field { ... on ProjectV2FieldCommon { id } } } ... on ProjectV2ItemFieldSingleSelectValue { name optionId } } pageInfo { hasNextPage endCursor } } } }
+    item: node(id: $itemId) { ... on ProjectV2Item { fieldValues(first: $pageSize, after: $cursor) { edges { cursor node { ${FIELD_VALUE_SELECTION} } } pageInfo { hasNextPage endCursor } } } }
+  }`,
+  userMembers: `query PlanningObservationUserMembers($itemId: ID!, $valueAfter: String, $memberCursor: String!, $pageSize: Int!) {
+    item: node(id: $itemId) { ... on ProjectV2Item { fieldValues(first: 1, after: $valueAfter) { edges { cursor node { __typename ... on ProjectV2ItemFieldUserValue { field { ... on ProjectV2FieldCommon { id } } users(first: $pageSize, after: $memberCursor) { nodes { id } pageInfo { hasNextPage endCursor } } } } } } } }
+  }`,
+  labelMembers: `query PlanningObservationLabelMembers($itemId: ID!, $valueAfter: String, $memberCursor: String!, $pageSize: Int!) {
+    item: node(id: $itemId) { ... on ProjectV2Item { fieldValues(first: 1, after: $valueAfter) { edges { cursor node { __typename ... on ProjectV2ItemFieldLabelValue { field { ... on ProjectV2FieldCommon { id } } labels(first: $pageSize, after: $memberCursor) { nodes { id } pageInfo { hasNextPage endCursor } } } } } } } }
   }`,
   end: `query PlanningObservationEnd($repositoryId: ID!, $issueId: ID!, $projectId: ID!, $itemId: ID!, $statusFieldId: ID!, $pageSize: Int!) {
-    repository: node(id: $repositoryId) { id }
+    repository: node(id: $repositoryId) { __typename id }
     issue: node(id: $issueId) { id ... on Issue { number state body updatedAt } }
     project: node(id: $projectId) { id ... on ProjectV2 {
       items(first: $pageSize) { nodes { id content { __typename ... on Issue { id } ... on PullRequest { id } ... on DraftIssue { id } } } pageInfo { hasNextPage endCursor } }
       fields(first: $pageSize) { nodes { ... on ProjectV2FieldCommon { id name } ... on ProjectV2SingleSelectField { options { id name color description } } } pageInfo { hasNextPage endCursor } }
     } }
-    item: node(id: $itemId) { id ... on ProjectV2Item { content { __typename ... on Issue { id } } fieldValues(first: $pageSize) { nodes { __typename ... on ProjectV2ItemFieldValueCommon { id field { ... on ProjectV2FieldCommon { id } } } ... on ProjectV2ItemFieldSingleSelectValue { name optionId } } pageInfo { hasNextPage endCursor } } } }
+    item: node(id: $itemId) { id ... on ProjectV2Item { content { __typename ... on Issue { id } } fieldValues(first: $pageSize) { edges { cursor node { ${FIELD_VALUE_SELECTION} } } pageInfo { hasNextPage endCursor } } } }
     statusField: node(id: $statusFieldId) { id ... on ProjectV2SingleSelectField { name options { id name color description } } }
   }`,
 });
 
-const DEFAULT_LIMITS = Object.freeze({ pageSize: 100, pages: 100, items: 10_000, fields: 1_000, values: 1_000, bodyBytes: 1_000_000 });
+const DEFAULT_LIMITS = Object.freeze({ pageSize: 100, pages: 100, items: 10_000, fields: 1_000, values: 1_000, users: 1_000, labels: 1_000, bodyBytes: 1_000_000 });
 
 function isRecord(value) {
   return value !== null && typeof value === "object" && !Array.isArray(value);
@@ -58,7 +90,7 @@ function pageFailure(component, pageInfo) {
   return null;
 }
 
-async function exhaustConnection({ transport, query, variables, initial, component, nodePath, limitName, limit, pageLimit }) {
+async function exhaustConnection({ transport, query, variables, initial, component, nodePath, limitName, limit, pageLimit, cursorName = "cursor" }) {
   const nodes = [];
   let connection = initial;
   let pages = 0;
@@ -71,14 +103,120 @@ async function exhaustConnection({ transport, query, variables, initial, compone
     nodes.push(...connection.nodes);
     if (!connection.pageInfo.hasNextPage) return { ok: true, value: nodes };
     if (pages >= pageLimit) return providerDiagnostic("OBSERVATION_LIMIT", "limit", `limit:pages:${pages}/${pageLimit}`);
-    const response = await request(transport, query, { ...variables, cursor: connection.pageInfo.endCursor });
+    const response = await request(transport, query, { ...variables, [cursorName]: connection.pageInfo.endCursor });
     if (!response.ok) return response;
     connection = nodePath(response.value);
   }
 }
 
+async function exhaustFieldValues({ transport, initial, itemId, limits, component }) {
+  const values = [];
+  const cursors = new Set();
+  let connection = initial;
+  let pages = 0;
+  let valueAfter = null;
+  for (;;) {
+    pages += 1;
+    const closure = pageFailure(component, connection?.pageInfo);
+    if (closure) return closure;
+    if (!Array.isArray(connection.edges)) return inaccessible();
+    if (values.length + connection.edges.length > limits.values) return providerDiagnostic("OBSERVATION_LIMIT", "limit", `limit:values:${values.length + connection.edges.length}/${limits.values}`);
+    for (const edge of connection.edges) {
+      if (!isRecord(edge) || typeof edge.cursor !== "string" || edge.cursor.length === 0 || !isRecord(edge.node)) return inaccessible();
+      if (cursors.has(edge.cursor)) return providerDiagnostic("IDENTITY_AMBIGUOUS", "identity", "count:2");
+      cursors.add(edge.cursor);
+      values.push({ node: edge.node, locator: { after: valueAfter, cursor: edge.cursor } });
+      valueAfter = edge.cursor;
+    }
+    if (!connection.pageInfo.hasNextPage) return { ok: true, value: values };
+    if (connection.edges.length > 0 && valueAfter !== connection.pageInfo.endCursor) return providerDiagnostic("PAGINATION_INCOMPLETE", "connection", `component:${component}`);
+    valueAfter = connection.pageInfo.endCursor;
+    if (pages >= limits.pages) return providerDiagnostic("OBSERVATION_LIMIT", "limit", `limit:pages:${pages}/${limits.pages}`);
+    const response = await request(transport, QUERY_DOCUMENTS.values, { itemId, cursor: connection.pageInfo.endCursor, pageSize: limits.pageSize });
+    if (!response.ok) return response;
+    connection = response.value.item?.fieldValues;
+  }
+}
+
+function nestedMemberConnection(data, locator, typename, fieldId, connectionName) {
+  const edges = data.item?.fieldValues?.edges;
+  if (!Array.isArray(edges) || edges.length !== 1) return undefined;
+  const [edge] = edges;
+  if (!isRecord(edge) || edge.cursor !== locator.cursor || edge.node?.__typename !== typename || edge.node?.field?.id !== fieldId) return undefined;
+  return edge.node[connectionName];
+}
+
+function memberIds(nodes) {
+  if (!nodes.every((member) => isRecord(member) && typeof member.id === "string" && member.id.length > 0)) return inaccessible();
+  const ids = nodes.map(({ id }) => id).sort((left, right) => Buffer.compare(Buffer.from(left), Buffer.from(right)));
+  for (let index = 0; index < ids.length;) {
+    let next = index + 1;
+    while (next < ids.length && ids[next] === ids[index]) next += 1;
+    if (next - index > 1) return providerDiagnostic("IDENTITY_AMBIGUOUS", "identity", `count:${next - index}`);
+    index = next;
+  }
+  return { ok: true, value: ids };
+}
+
+async function exhaustNestedMembers({ transport, entry, limits, prefix, typename, connectionName, query, limitName }) {
+  const fieldId = entry.node.field?.id;
+  if (typeof fieldId !== "string" || fieldId.length === 0 || !isRecord(entry.node[connectionName])) return inaccessible();
+  const members = await exhaustConnection({
+    transport,
+    query,
+    variables: { itemId: entry.itemId, valueAfter: entry.locator.after, pageSize: limits.pageSize },
+    initial: entry.node[connectionName],
+    component: `${prefix}-${limitName}-members`,
+    nodePath: (data) => nestedMemberConnection(data, entry.locator, typename, fieldId, connectionName),
+    limitName,
+    limit: limits[limitName],
+    pageLimit: limits.pages,
+    cursorName: "memberCursor",
+  });
+  if (!members.ok) return members;
+  return memberIds(members.value);
+}
+
+async function normalizeFieldValues(transport, entries, itemId, limits, prefix) {
+  const values = [];
+  for (const located of entries) {
+    const entry = { ...located, itemId };
+    const value = entry.node;
+    const fieldId = value.field?.id;
+    if (typeof value.__typename !== "string" || typeof fieldId !== "string" || fieldId.length === 0) return inaccessible();
+    if (value.__typename === "ProjectV2ItemFieldUserValue") {
+      const users = await exhaustNestedMembers({ transport, entry, limits, prefix, typename: value.__typename, connectionName: "users", query: QUERY_DOCUMENTS.userMembers, limitName: "users" });
+      if (!users.ok) return users;
+      values.push({ valueType: value.__typename, fieldId, userIds: users.value });
+    } else if (value.__typename === "ProjectV2ItemFieldRepositoryValue") {
+      if (typeof value.repository?.id !== "string" || value.repository.id.length === 0) return inaccessible();
+      values.push({ valueType: value.__typename, fieldId, repositoryId: value.repository.id });
+    } else if (value.__typename === "ProjectV2ItemFieldLabelValue") {
+      const labels = await exhaustNestedMembers({ transport, entry, limits, prefix, typename: value.__typename, connectionName: "labels", query: QUERY_DOCUMENTS.labelMembers, limitName: "labels" });
+      if (!labels.ok) return labels;
+      values.push({ valueType: value.__typename, fieldId, labelIds: labels.value });
+    } else if (value.__typename === "ProjectV2ItemFieldTextValue") {
+      if (typeof value.id !== "string" || value.id.length === 0 || !Object.hasOwn(value, "text") || (value.text !== null && typeof value.text !== "string")) return inaccessible();
+      values.push({ valueType: value.__typename, fieldId, valueIdentity: value.id, text: value.text });
+    } else if (value.__typename === "ProjectV2ItemFieldSingleSelectValue") {
+      if ([value.id, value.name, value.optionId].some((part) => typeof part !== "string" || part.length === 0)) return inaccessible();
+      values.push({ valueType: value.__typename, fieldId, valueIdentity: value.id, name: value.name, optionId: value.optionId });
+    } else {
+      return inaccessible();
+    }
+  }
+  const identities = values.map(({ fieldId }) => canonicalJson(fieldId)).sort();
+  for (let index = 0; index < identities.length;) {
+    let next = index + 1;
+    while (next < identities.length && identities[next] === identities[index]) next += 1;
+    if (next - index > 1) return providerDiagnostic("IDENTITY_AMBIGUOUS", "identity", `count:${next - index}`);
+    index = next;
+  }
+  return { ok: true, value: values };
+}
+
 function selectedStatus(values, fieldId) {
-  return values.filter((value) => value?.field?.id === fieldId && value?.__typename === "ProjectV2ItemFieldSingleSelectValue" && typeof value.name === "string" && typeof value.optionId === "string");
+  return values.filter((value) => value.fieldId === fieldId && value.valueType === "ProjectV2ItemFieldSingleSelectValue");
 }
 
 function compareTuple(left, right, fields) {
@@ -98,8 +236,8 @@ function closureSummary(items, fields, values, itemId, statusFieldId, statusValu
     options: (field.options ?? []).map((option) => ({ optionId: option.id, name: option.name, color: option.color, description: option.description }))
       .sort((left, right) => compareTuple(left, right, ["optionId", "name"])),
   })).sort((left, right) => compareTuple(left, right, ["fieldId", "name"]));
-  const valueRecords = values.map((value) => ({ fieldId: value.field.id, valueType: value.__typename, valueIdentity: value.id }))
-    .sort((left, right) => compareTuple(left, right, ["fieldId", "valueType", "valueIdentity"]));
+  const valueRecords = values.map((value) => structuredClone(value))
+    .sort((left, right) => Buffer.compare(Buffer.from(canonicalJson(left)), Buffer.from(canonicalJson(right))));
   return {
     items: itemRecords,
     fields: fieldRecords,
@@ -122,35 +260,52 @@ function identityResult(code, field, actual, expected) {
   return providerDiagnostic(code, field, `pair:${hash(actual)}/${hash(expected)}`);
 }
 
-function validClosureNodes(items, fields, values) {
+function validClosureNodes(items, fields) {
   return items.every((entry) => typeof entry?.id === "string" && typeof entry?.content?.id === "string") &&
-    fields.every((field) => typeof field?.id === "string" && typeof field?.name === "string" && (field.options === undefined || (Array.isArray(field.options) && field.options.every((option) => [option?.id, option?.name, option?.color, option?.description].every((value) => typeof value === "string"))))) &&
-    values.every((value) => typeof value?.id === "string" && typeof value?.__typename === "string" && typeof value?.field?.id === "string");
+    fields.every((field) => typeof field?.id === "string" && typeof field?.name === "string" && (field.options === undefined || (Array.isArray(field.options) && field.options.every((option) => [option?.id, option?.name, option?.color, option?.description].every((value) => typeof value === "string")))));
 }
 
 function validateClosure({ items, fields, values, item, expected, end = false }) {
-  if (!validClosureNodes(items, fields, values)) return inaccessible();
+  if (!validClosureNodes(items, fields)) return inaccessible();
+  const fieldIds = fields.map(({ id }) => id).sort();
+  for (let index = 1; index < fieldIds.length; index += 1) {
+    if (fieldIds[index] === fieldIds[index - 1]) return providerDiagnostic("IDENTITY_AMBIGUOUS", "identity", "count:2");
+  }
   const boundItems = items.filter((candidate) => candidate.content.id === expected.issueId);
   if (boundItems.length > 1) return providerDiagnostic("PROJECT_ITEM_DUPLICATE", "projectItem", `count:${boundItems.length}`);
   if (boundItems.length !== 1) return providerDiagnostic("IDENTITY_AMBIGUOUS", "identity", `count:${boundItems.length}`);
+  const itemIds = items.map(({ id }) => id).sort();
+  for (let index = 1; index < itemIds.length; index += 1) {
+    if (itemIds[index] === itemIds[index - 1]) return providerDiagnostic("IDENTITY_AMBIGUOUS", "identity", "count:2");
+  }
+  for (const field of fields) {
+    const optionIds = (field.options ?? []).map(({ id }) => id).sort();
+    for (let index = 1; index < optionIds.length; index += 1) {
+      if (optionIds[index] === optionIds[index - 1]) return providerDiagnostic("IDENTITY_AMBIGUOUS", "identity", "count:2");
+    }
+  }
   if (boundItems[0].id !== expected.itemId) return identityResult("ITEM_ID_MISMATCH", "itemId", boundItems[0].id, expected.itemId);
   if (item.content?.id !== expected.issueId) return end ? providerDiagnostic("IDENTITY_AMBIGUOUS", "identity", "count:0") : identityResult("ISSUE_ID_MISMATCH", "issueId", item.content?.id, expected.issueId);
   const matchingFields = fields.filter((field) => field.id === expected.statusFieldId);
   if (matchingFields.length !== 1) return providerDiagnostic("IDENTITY_AMBIGUOUS", "identity", `count:${matchingFields.length}`);
+  if (!values.every(({ fieldId }) => fieldIds.includes(fieldId))) return inaccessible();
   const selected = selectedStatus(values, expected.statusFieldId);
   if (selected.length !== 1) return providerDiagnostic("IDENTITY_AMBIGUOUS", "identity", `count:${selected.length}`);
   const matchingOptions = (matchingFields[0].options ?? []).filter((option) => option.id === selected[0].optionId);
   if (matchingOptions.length !== 1) return providerDiagnostic("IDENTITY_AMBIGUOUS", "identity", `count:${matchingOptions.length}`);
+  if (matchingOptions[0].name !== selected[0].name) return inaccessible();
   return { ok: true, value: { selected: selected[0], selectedOption: matchingOptions[0], summary: closureSummary(items, fields, values, item.id, matchingFields[0].id, selected[0]) } };
 }
 
 async function enumerateClosure(transport, data, expected, limits, prefix) {
-  const [items, fields, values] = await Promise.all([
+  const [items, fields, valueEntries] = await Promise.all([
     exhaustConnection({ transport, query: QUERY_DOCUMENTS.items, variables: { projectId: expected.projectId, pageSize: limits.pageSize }, initial: data.project.items, component: `${prefix}-project-items`, nodePath: (page) => page.project?.items, limitName: "items", limit: limits.items, pageLimit: limits.pages }),
     exhaustConnection({ transport, query: QUERY_DOCUMENTS.fields, variables: { projectId: expected.projectId, pageSize: limits.pageSize }, initial: data.project.fields, component: `${prefix}-project-fields`, nodePath: (page) => page.project?.fields, limitName: "fields", limit: limits.fields, pageLimit: limits.pages }),
-    exhaustConnection({ transport, query: QUERY_DOCUMENTS.values, variables: { itemId: expected.itemId, pageSize: limits.pageSize }, initial: data.item.fieldValues, component: `${prefix}-item-field-values`, nodePath: (page) => page.item?.fieldValues, limitName: "values", limit: limits.values, pageLimit: limits.pages }),
+    exhaustFieldValues({ transport, initial: data.item.fieldValues, itemId: expected.itemId, limits, component: `${prefix}-item-field-values` }),
   ]);
-  for (const result of [items, fields, values]) if (!result.ok) return result;
+  for (const result of [items, fields, valueEntries]) if (!result.ok) return result;
+  const values = await normalizeFieldValues(transport, valueEntries.value, expected.itemId, limits, prefix);
+  if (!values.ok) return values;
   return { ok: true, value: { items: items.value, fields: fields.value, values: values.value } };
 }
 
@@ -172,6 +327,7 @@ export async function observePlanning(expectedEnvelope, options) {
   if (!start.ok) return start;
   const { repository, issue, project, item, statusField } = start.value;
   if (![repository, issue, project, item, statusField].every(isRecord)) return inaccessible();
+  if (repository.__typename !== "Repository") return inaccessible();
   if (Buffer.byteLength(issue.body ?? "", "utf8") > limits.bodyBytes) return providerDiagnostic("OBSERVATION_LIMIT", "limit", `limit:body-bytes:${Buffer.byteLength(issue.body ?? "", "utf8")}/${limits.bodyBytes}`);
 
   const identityChecks = [
@@ -193,6 +349,7 @@ export async function observePlanning(expectedEnvelope, options) {
   if (!end.ok) return end;
   const endData = end.value;
   if (![endData.repository, endData.issue, endData.project, endData.item, endData.statusField].every(isRecord)) return inaccessible();
+  if (endData.repository.__typename !== "Repository") return inaccessible();
   for (const [code, field, actual, wanted] of [
     ["REPOSITORY_ID_MISMATCH", "repositoryId", endData.repository.id, expected.repositoryId],
     ["PROJECT_ID_MISMATCH", "projectId", endData.project.id, expected.projectId],

--- a/utl/gh/planning-github-observer.test.mjs
+++ b/utl/gh/planning-github-observer.test.mjs
@@ -19,6 +19,10 @@ function expectedEnvelope() {
   return { runtime: structuredClone(fixtures.baseEpic.runtime), expected: structuredClone(fixtures.baseEpic.expected) };
 }
 
+function standaloneEnvelope() {
+  return { runtime: structuredClone(fixtures.baseStandalone.runtime), expected: structuredClone(fixtures.baseStandalone.expected) };
+}
+
 function statusOption(name = "Backlog") {
   const options = {
     Backlog: { id: "O_backlog", name: "Backlog", color: "GRAY", description: "Captured for consideration; material preparation has not started." },
@@ -39,7 +43,19 @@ function issue(overrides = {}) {
 }
 
 function page(nodes, hasNextPage = false, endCursor = null) {
-  return { nodes, pageInfo: { hasNextPage, endCursor } };
+  const connection = { nodes, pageInfo: { hasNextPage, endCursor } };
+  Object.defineProperty(connection, "edges", {
+    enumerable: true,
+    get() {
+      return this.nodes.map((node, index) => ({
+        cursor: index === this.nodes.length - 1 && typeof this.pageInfo.endCursor === "string"
+          ? this.pageInfo.endCursor
+          : `cursor:${index}:${node.id ?? node.field?.id ?? node.__typename ?? "node"}`,
+        node,
+      }));
+    },
+  });
+  return connection;
 }
 
 function projectItem(id = "PVTI_item", contentId = "I_issue") {
@@ -54,11 +70,80 @@ function statusValue(name = "Backlog", option = statusOption()) {
   return { __typename: "ProjectV2ItemFieldSingleSelectValue", id: "PVTFV_status", name, optionId: option.id, field: { id: "PVTF_status" } };
 }
 
+function optionalValue(kind, memberIds = ["M_1", "M_2"]) {
+  const definitions = {
+    User: {
+      field: { id: "PVTF_users", name: "Users" },
+      value: { __typename: "ProjectV2ItemFieldUserValue", field: { id: "PVTF_users" }, users: page(memberIds.map((id) => ({ id }))) },
+    },
+    Repository: {
+      field: { id: "PVTF_repository", name: "Repository" },
+      value: { __typename: "ProjectV2ItemFieldRepositoryValue", field: { id: "PVTF_repository" }, repository: { id: "R_value" } },
+    },
+    Label: {
+      field: { id: "PVTF_labels", name: "Labels" },
+      value: { __typename: "ProjectV2ItemFieldLabelValue", field: { id: "PVTF_labels" }, labels: page(memberIds.map((id) => ({ id: `L_${id}` }))) },
+    },
+    Text: {
+      field: { id: "PVTF_text", name: "Text" },
+      value: { __typename: "ProjectV2ItemFieldTextValue", id: "PVTFV_text", field: { id: "PVTF_text" }, text: null },
+    },
+  };
+  return structuredClone(definitions[kind]);
+}
+
+function addOptionalValue(snapshot, kind, memberIds) {
+  const definition = optionalValue(kind, memberIds);
+  snapshot.project.fields.nodes.push(definition.field);
+  snapshot.item.fieldValues.nodes.push(definition.value);
+  return definition.value;
+}
+
+function addMixedSupportedValues(snapshot, reverse = false) {
+  const fields = [
+    { id: "PVTF_users", name: "Users" },
+    { id: "PVTF_repository", name: "Repository" },
+    { id: "PVTF_labels", name: "Labels" },
+    { id: "PVTF_text", name: "Text" },
+  ];
+  const memberIds = reverse ? ["M_2", "M_1"] : ["M_1", "M_2"];
+  const values = [
+    { __typename: "ProjectV2ItemFieldUserValue", field: { id: "PVTF_users" }, users: page(memberIds.map((id) => ({ id }))) },
+    { __typename: "ProjectV2ItemFieldRepositoryValue", field: { id: "PVTF_repository" }, repository: { id: "R_value" } },
+    { __typename: "ProjectV2ItemFieldLabelValue", field: { id: "PVTF_labels" }, labels: page(memberIds.map((id) => ({ id: `L_${id}` }))) },
+    { __typename: "ProjectV2ItemFieldTextValue", id: "PVTFV_text", field: { id: "PVTF_text" }, text: null },
+  ];
+  snapshot.project.fields.nodes.push(...(reverse ? fields.reverse() : fields));
+  snapshot.item.fieldValues.nodes.push(...(reverse ? values.reverse() : values));
+}
+
+function edgePage(entries, hasNextPage = false, endCursor = null) {
+  return { edges: entries, pageInfo: { hasNextPage, endCursor } };
+}
+
+function nestedMemberData(value, valueCursor, connectionName, connection, overrides = {}) {
+  return {
+    item: {
+      fieldValues: {
+        edges: [{
+          cursor: valueCursor,
+          node: {
+            __typename: value.__typename,
+            field: { id: value.field.id },
+            [connectionName]: connection,
+            ...overrides,
+          },
+        }],
+      },
+    },
+  };
+}
+
 function transportFixture(overrides = {}) {
   const calls = [];
   const option = statusOption();
   const start = {
-    repository: { id: "R_repo" },
+    repository: { __typename: "Repository", id: "R_repo" },
     issue: issue(),
     project: {
       id: "P_project",
@@ -73,7 +158,7 @@ function transportFixture(overrides = {}) {
     statusField: { id: "PVTF_status", name: "Status", options: [structuredClone(option)] },
   };
   const end = {
-    repository: { id: "R_repo" },
+    repository: { __typename: "Repository", id: "R_repo" },
     issue: issue(),
     project: { id: "P_project", items: page([projectItem()]), fields: page([projectField(structuredClone(option))]) },
     item: {
@@ -94,16 +179,21 @@ function transportFixture(overrides = {}) {
     if (query === QUERY_DOCUMENTS.items) return { data: { project: { items: overrides.itemPages?.[variables.cursor] ?? overrides.itemsPage ?? page([]) } } };
     if (query === QUERY_DOCUMENTS.fields) return { data: { project: { fields: overrides.fieldPages?.[variables.cursor] ?? overrides.fieldsPage ?? page([]) } } };
     if (query === QUERY_DOCUMENTS.values) return { data: { item: { fieldValues: overrides.valuePages?.[variables.cursor] ?? overrides.valuesPage ?? page([]) } } };
+    if (query === QUERY_DOCUMENTS.userMembers || query === QUERY_DOCUMENTS.labelMembers) {
+      const memberPage = overrides.memberPages?.[variables.memberCursor];
+      if (memberPage !== undefined) return { data: memberPage };
+    }
     throw new Error("unexpected query");
   };
   return { transport, calls, start, end };
 }
 
-function expectCode(result, code) {
+function expectCode(result, code, forbidden = []) {
   assert.equal(result.ok, false);
   assert.deepEqual(result.diagnostics.map((item) => item.code), [code]);
   const serialized = JSON.stringify(result);
   assert.equal(serialized.includes("SECRET_PROVIDER_PAYLOAD"), false);
+  for (const marker of forbidden) assert.equal(serialized.includes(marker), false);
 }
 
 function runCli(mode, flag, input) {
@@ -151,6 +241,8 @@ test("observer exports only read APIs and every constant GraphQL document is a q
 
 test("complete stable observation binds every identity and validates without network or credentials", async () => {
   const fixture = transportFixture();
+  addMixedSupportedValues(fixture.start);
+  addMixedSupportedValues(fixture.end, true);
   const observed = await observePlanning(expectedEnvelope(), { transport: fixture.transport });
   assert.equal(observed.ok, true, JSON.stringify(observed));
   assert.equal(fixture.calls.length, 2);
@@ -159,6 +251,61 @@ test("complete stable observation binds every identity and validates without net
   assert.equal(verdict.ok, true, JSON.stringify(verdict));
   assert.equal(verdict.value.claim, "epic-contract-consistency");
   assert.equal(verdict.value.authorityEffect, "none");
+});
+
+test("each supported field-value variant uses only its minimal provider projection", async () => {
+  for (const kind of ["SingleSelect", "User", "Repository", "Label", "Text"]) {
+    const fixture = transportFixture();
+    if (kind !== "SingleSelect") {
+      addOptionalValue(fixture.start, kind);
+      addOptionalValue(fixture.end, kind);
+    }
+    const observed = await observePlanning(expectedEnvelope(), { transport: fixture.transport });
+    assert.equal(observed.ok, true, `${kind}: ${JSON.stringify(observed)}`);
+  }
+});
+
+test("synthetic #128-shaped mixed closure remains Backlog evidence without workflow authority", async () => {
+  const fixture = transportFixture();
+  fixture.start.issue.number = 128;
+  fixture.end.issue.number = 128;
+  fixture.start.issue.body = fixtures.baseStandalone.issue.body;
+  fixture.end.issue.body = fixtures.baseStandalone.issue.body;
+  addMixedSupportedValues(fixture.start);
+  addMixedSupportedValues(fixture.end, true);
+  const observed = await observePlanning(standaloneEnvelope(), { transport: fixture.transport });
+  assert.equal(observed.ok, true, JSON.stringify(observed));
+  const verdict = validatePlanningObservation(observed.value);
+  assert.equal(verdict.ok, true, JSON.stringify(verdict));
+  assert.deepEqual({ claim: verdict.value.claim, status: verdict.value.status, authorityEffect: verdict.value.authorityEffect }, {
+    claim: "plan-status-only",
+    status: "Backlog",
+    authorityEffect: "none",
+  });
+  assert.doesNotMatch(JSON.stringify(verdict), /"(?:command|transition|mutation|calls?)"/iu);
+});
+
+test("canonical sorting independently tolerates top-level, User-member, and Label-member reordering", async () => {
+  const cases = [
+    ["top-level", (end) => {
+      end.project.items.nodes.reverse();
+      end.project.fields.nodes.reverse();
+      end.item.fieldValues.nodes.reverse();
+    }],
+    ["User members", (end) => { end.item.fieldValues.nodes.find(({ __typename }) => __typename === "ProjectV2ItemFieldUserValue").users.nodes.reverse(); }],
+    ["Label members", (end) => { end.item.fieldValues.nodes.find(({ __typename }) => __typename === "ProjectV2ItemFieldLabelValue").labels.nodes.reverse(); }],
+  ];
+  for (const [name, reorder] of cases) {
+    const fixture = transportFixture();
+    addMixedSupportedValues(fixture.start);
+    addMixedSupportedValues(fixture.end);
+    fixture.start.project.items.nodes.push(projectItem("PVTI_other", "I_other"));
+    fixture.end.project.items.nodes.push(projectItem("PVTI_other", "I_other"));
+    reorder(fixture.end);
+    const result = await observePlanning(expectedEnvelope(), { transport: fixture.transport });
+    assert.equal(result.ok, true, `${name}: ${JSON.stringify(result)}`);
+    assert.equal(result.value.window.startFingerprint, result.value.window.endFingerprint);
+  }
 });
 
 test("start and end independently enumerate stable multipage closures", async () => {
@@ -183,13 +330,55 @@ test("start and end independently enumerate stable multipage closures", async ()
   assert.deepEqual(new Set(wrapped.calls.filter(({ variables }) => variables.cursor).map(({ variables }) => variables.cursor)), new Set(["items-1", "fields-1", "values-1", "end-items-1", "end-fields-1", "end-values-1"]));
 });
 
+test("outer values and nested User and Label members paginate independently at both window endpoints", async () => {
+  const fixture = transportFixture();
+  function configure(snapshot, prefix) {
+    const definitions = [optionalValue("User"), optionalValue("Repository"), optionalValue("Label"), optionalValue("Text")];
+    snapshot.project.fields.nodes.push(...definitions.map(({ field }) => field));
+    const user = definitions[0].value;
+    const label = definitions[2].value;
+    user.users = page([{ id: "M_1" }], true, `${prefix}-users-1`);
+    label.labels = page([{ id: "L_M_1" }], true, `${prefix}-labels-1`);
+    snapshot.item.fieldValues = page([statusValue()], true, `${prefix}-values-1`);
+    const continuation = page(definitions.map(({ value }) => value));
+    return { continuation, user, label };
+  }
+  const start = configure(fixture.start, "start");
+  const end = configure(fixture.end, "end");
+  const valuePages = {
+    "start-values-1": start.continuation,
+    "end-values-1": end.continuation,
+  };
+  const startUserCursor = start.continuation.edges.find(({ node }) => node === start.user).cursor;
+  const startLabelCursor = start.continuation.edges.find(({ node }) => node === start.label).cursor;
+  const endUserCursor = end.continuation.edges.find(({ node }) => node === end.user).cursor;
+  const endLabelCursor = end.continuation.edges.find(({ node }) => node === end.label).cursor;
+  const memberPages = {
+    "start-users-1": nestedMemberData(start.user, startUserCursor, "users", page([{ id: "M_2" }])),
+    "end-users-1": nestedMemberData(end.user, endUserCursor, "users", page([{ id: "M_2" }])),
+    "start-labels-1": nestedMemberData(start.label, startLabelCursor, "labels", page([{ id: "L_M_2" }])),
+    "end-labels-1": nestedMemberData(end.label, endLabelCursor, "labels", page([{ id: "L_M_2" }])),
+  };
+  const wrapped = transportFixture({ start: fixture.start, end: fixture.end, valuePages, memberPages });
+  const result = await observePlanning(expectedEnvelope(), { transport: wrapped.transport });
+  assert.equal(result.ok, true, JSON.stringify(result));
+  assert.deepEqual(
+    wrapped.calls.filter(({ variables }) => variables.cursor).map(({ variables }) => variables.cursor).sort(),
+    ["end-values-1", "start-values-1"],
+  );
+  assert.deepEqual(
+    wrapped.calls.filter(({ variables }) => variables.memberCursor).map(({ variables }) => variables.memberCursor).sort(),
+    ["end-labels-1", "end-users-1", "start-labels-1", "start-users-1"],
+  );
+});
+
 test("canonical closure sorting makes provider enumeration order irrelevant", async () => {
   const fixture = transportFixture();
   const backlog = statusOption();
   const refinement = statusOption("Refinement");
   const otherItem = projectItem("PVTI_other", "I_other");
   const otherField = { id: "PVTF_other", name: "Other" };
-  const otherValue = { __typename: "ProjectV2ItemFieldTextValue", id: "PVTFV_other", field: { id: "PVTF_other" } };
+  const otherValue = { __typename: "ProjectV2ItemFieldTextValue", id: "PVTFV_other", field: { id: "PVTF_other" }, text: null };
   fixture.start.project.items.nodes.push(otherItem);
   fixture.start.project.fields.nodes[0].options.push(refinement);
   fixture.start.project.fields.nodes.push(otherField);
@@ -205,6 +394,89 @@ test("pagination without a closing cursor fails distinctly", async () => {
   const fixture = transportFixture();
   fixture.start.project.items = page([], true, null);
   expectCode(await observePlanning(expectedEnvelope(), { transport: fixture.transport }), "PAGINATION_INCOMPLETE");
+});
+
+test("malformed required members and unsupported variants fail closed with one redacted diagnostic", async () => {
+  const cases = [
+    ["User field", { __typename: "ProjectV2ItemFieldUserValue", field: {}, users: page([]) }],
+    ["User connection", { __typename: "ProjectV2ItemFieldUserValue", field: { id: "PVTF_bad" } }],
+    ["Repository identity", { __typename: "ProjectV2ItemFieldRepositoryValue", field: { id: "PVTF_bad" }, repository: { id: "" } }],
+    ["Label connection", { __typename: "ProjectV2ItemFieldLabelValue", field: { id: "PVTF_bad" }, labels: null }],
+    ["Text value identity", { __typename: "ProjectV2ItemFieldTextValue", field: { id: "PVTF_bad" }, text: null }],
+    ["Text presence", { __typename: "ProjectV2ItemFieldTextValue", id: "PVTFV_bad", field: { id: "PVTF_bad" } }],
+    ["Text type", { __typename: "ProjectV2ItemFieldTextValue", id: "PVTFV_bad", field: { id: "PVTF_bad" }, text: { secret: "SECRET_TEXT_TYPE" } }],
+    ["SingleSelect option", { __typename: "ProjectV2ItemFieldSingleSelectValue", id: "PVTFV_bad", field: { id: "PVTF_bad" }, name: "Bad" }],
+    ["unknown variant", { __typename: "ProjectV2ItemFieldIterationValue_SECRET_UNKNOWN", field: { id: "PVTF_bad" } }],
+  ];
+  for (const [name, value] of cases) {
+    const fixture = transportFixture();
+    fixture.start.project.fields.nodes.push({ id: "PVTF_bad", name: "Bad" });
+    fixture.start.item.fieldValues.nodes.push(value);
+    const result = await observePlanning(expectedEnvelope(), { transport: fixture.transport });
+    assert.doesNotThrow(() => expectCode(result, "PROVIDER_INACCESSIBLE", ["SECRET_TEXT_TYPE", "SECRET_UNKNOWN"]), name);
+  }
+});
+
+test("outer field-value pagination fails on missing cursor, locator truncation, repeated cursor, and limits", async () => {
+  const missingCursor = transportFixture();
+  missingCursor.start.item.fieldValues = edgePage([{ cursor: "value-1", node: statusValue() }], true, null);
+  expectCode(await observePlanning(expectedEnvelope(), { transport: missingCursor.transport }), "PAGINATION_INCOMPLETE");
+
+  const truncated = transportFixture();
+  truncated.start.item.fieldValues = edgePage([{ cursor: "value-1", node: statusValue() }], true, "different-end-cursor");
+  expectCode(await observePlanning(expectedEnvelope(), { transport: truncated.transport }), "PAGINATION_INCOMPLETE");
+
+  const repeated = transportFixture();
+  const text = optionalValue("Text");
+  repeated.start.project.fields.nodes.push(text.field);
+  repeated.start.item.fieldValues = edgePage([{ cursor: "shared-cursor", node: statusValue() }], true, "shared-cursor");
+  const repeatedTransport = transportFixture({
+    start: repeated.start,
+    end: repeated.end,
+    valuePages: { "shared-cursor": edgePage([{ cursor: "shared-cursor", node: text.value }]) },
+  });
+  expectCode(await observePlanning(expectedEnvelope(), { transport: repeatedTransport.transport }), "IDENTITY_AMBIGUOUS");
+
+  const capped = transportFixture();
+  addOptionalValue(capped.start, "Text");
+  expectCode(await observePlanning(expectedEnvelope(), { transport: capped.transport, limits: { values: 1 } }), "OBSERVATION_LIMIT");
+});
+
+test("nested User and Label pagination fails on incomplete closure, member limits, duplicates, and locator drift", async () => {
+  for (const kind of ["User", "Label"]) {
+    const connectionName = kind === "User" ? "users" : "labels";
+    const limitName = kind === "User" ? "users" : "labels";
+
+    const missingCursor = transportFixture();
+    const missingValue = addOptionalValue(missingCursor.start, kind);
+    missingValue[connectionName] = page([], true, null);
+    expectCode(await observePlanning(expectedEnvelope(), { transport: missingCursor.transport }), "PAGINATION_INCOMPLETE");
+
+    const pageCapped = transportFixture();
+    const cappedValue = addOptionalValue(pageCapped.start, kind);
+    cappedValue[connectionName] = page([], true, `${kind}-next`);
+    expectCode(await observePlanning(expectedEnvelope(), { transport: pageCapped.transport, limits: { pages: 1 } }), "OBSERVATION_LIMIT");
+
+    const memberCapped = transportFixture();
+    addOptionalValue(memberCapped.start, kind, ["duplicate-cap", "over-cap"]);
+    expectCode(await observePlanning(expectedEnvelope(), { transport: memberCapped.transport, limits: { [limitName]: 1 } }), "OBSERVATION_LIMIT");
+
+    const duplicate = transportFixture();
+    addOptionalValue(duplicate.start, kind, ["same", "same"]);
+    expectCode(await observePlanning(expectedEnvelope(), { transport: duplicate.transport }), "IDENTITY_AMBIGUOUS");
+
+    const locator = transportFixture();
+    const locatorValue = addOptionalValue(locator.start, kind);
+    locatorValue[connectionName] = page([], true, `${kind}-locator-next`);
+    const valueCursor = locator.start.item.fieldValues.edges.at(-1).cursor;
+    const drifted = nestedMemberData(locatorValue, `wrong-${valueCursor}`, connectionName, page([]));
+    const locatorTransport = transportFixture({
+      start: locator.start,
+      end: locator.end,
+      memberPages: { [`${kind}-locator-next`]: drifted },
+    });
+    expectCode(await observePlanning(expectedEnvelope(), { transport: locatorTransport.transport }), "PAGINATION_INCOMPLETE");
+  }
 });
 
 test("provider error payloads and transport exceptions fail inaccessible and remain redacted", async () => {
@@ -243,6 +515,42 @@ test("identity mismatch, duplicate binding, zero binding, and field ambiguity fa
   expectCode(await observePlanning(expectedEnvelope(), { transport: wrongItemContent.transport }), "ISSUE_ID_MISMATCH");
 });
 
+test("missing or wrong repository type fails redacted at both observation endpoints", async () => {
+  const cases = [
+    ["start", "missing"],
+    ["start", "wrong"],
+    ["end", "missing"],
+    ["end", "wrong"],
+  ];
+  for (const [endpoint, condition] of cases) {
+    const fixture = transportFixture();
+    const marker = `SECRET_${endpoint.toUpperCase()}_${condition.toUpperCase()}_REPOSITORY_TYPE`;
+    fixture[endpoint].repository.nameWithOwner = marker;
+    if (condition === "missing") delete fixture[endpoint].repository.__typename;
+    else fixture[endpoint].repository.__typename = marker;
+    expectCode(
+      await observePlanning(expectedEnvelope(), { transport: fixture.transport }),
+      "PROVIDER_INACCESSIBLE",
+      [marker],
+    );
+  }
+});
+
+test("duplicate selected Status and values bound to an unreturned field fail closed", async () => {
+  const duplicateStatus = transportFixture();
+  duplicateStatus.start.item.fieldValues.nodes.push({ ...statusValue(), id: "PVTFV_duplicate_status" });
+  expectCode(await observePlanning(expectedEnvelope(), { transport: duplicateStatus.transport }), "IDENTITY_AMBIGUOUS");
+
+  const unknownField = transportFixture();
+  unknownField.start.item.fieldValues.nodes.push({
+    __typename: "ProjectV2ItemFieldTextValue",
+    id: "PVTFV_unbound",
+    field: { id: "PVTF_unreturned" },
+    text: null,
+  });
+  expectCode(await observePlanning(expectedEnvelope(), { transport: unknownField.transport }), "PROVIDER_INACCESSIBLE");
+});
+
 test("configured item, page, and body ceilings stop before incomplete evidence can validate", async () => {
   const items = transportFixture();
   items.start.project.items.nodes.push(projectItem("other", "other"));
@@ -261,18 +569,70 @@ test("ordinary end body, state, selected-status, or complete schema movement is 
     (end) => { end.issue.updatedAt = "2026-08-14T00:00:01Z"; },
     (end) => { end.issue.body += "moved"; },
     (end) => { end.issue.state = "CLOSED"; },
-    (end) => { end.item.fieldValues.nodes[0].name = "Refinement"; },
+    (end) => {
+      const refinement = statusOption("Refinement");
+      end.project.fields.nodes[0].options.push(refinement);
+      end.item.fieldValues.nodes[0].name = refinement.name;
+      end.item.fieldValues.nodes[0].optionId = refinement.id;
+    },
     (end) => { end.project.fields.nodes[0].options[0].description = "moved"; },
     (end) => { end.project.fields.nodes[0].options.push(statusOption("Refinement")); },
     (end) => { end.project.items.nodes.push(projectItem("PVTI_other", "I_other")); },
     (end) => { end.project.fields.nodes.push({ id: "PVTF_other", name: "Other" }); },
-    (end) => { end.item.fieldValues.nodes.push({ __typename: "ProjectV2ItemFieldTextValue", id: "PVTFV_other", field: { id: "PVTF_other" } }); },
+    (end) => {
+      end.project.fields.nodes.push({ id: "PVTF_other", name: "Other" });
+      end.item.fieldValues.nodes.push({ __typename: "ProjectV2ItemFieldTextValue", id: "PVTFV_other", field: { id: "PVTF_other" }, text: null });
+    },
   ];
   for (const mutate of mutations) {
     const fixture = transportFixture();
     mutate(fixture.end);
     expectCode(await observePlanning(expectedEnvelope(), { transport: fixture.transport }), "OBSERVATION_DRIFT");
   }
+});
+
+test("semantic movement in every supported field-value variant is observation drift", async () => {
+  const cases = [
+    ["User", (value) => { value.users.nodes.push({ id: "M_3" }); }],
+    ["Repository", (value) => { value.repository.id = "R_moved"; }],
+    ["Label", (value) => { value.labels.nodes.push({ id: "L_M_3" }); }],
+    ["Text", (value) => { value.text = "moved"; }],
+  ];
+  for (const [kind, mutate] of cases) {
+    const fixture = transportFixture();
+    addOptionalValue(fixture.start, kind);
+    const endValue = addOptionalValue(fixture.end, kind);
+    mutate(endValue);
+    expectCode(await observePlanning(expectedEnvelope(), { transport: fixture.transport }), "OBSERVATION_DRIFT");
+  }
+
+  const singleSelect = transportFixture();
+  const refinement = statusOption("Refinement");
+  singleSelect.end.project.fields.nodes[0].options.push(refinement);
+  singleSelect.end.item.fieldValues.nodes[0].name = refinement.name;
+  singleSelect.end.item.fieldValues.nodes[0].optionId = refinement.id;
+  expectCode(await observePlanning(expectedEnvelope(), { transport: singleSelect.transport }), "OBSERVATION_DRIFT");
+});
+
+test("field-value payloads and mismatched identities remain redacted in diagnostics", async () => {
+  const textDrift = transportFixture();
+  const startText = addOptionalValue(textDrift.start, "Text");
+  const endText = addOptionalValue(textDrift.end, "Text");
+  startText.text = "SECRET_START_TEXT_PAYLOAD";
+  endText.text = "SECRET_END_TEXT_PAYLOAD";
+  expectCode(
+    await observePlanning(expectedEnvelope(), { transport: textDrift.transport }),
+    "OBSERVATION_DRIFT",
+    ["SECRET_START_TEXT_PAYLOAD", "SECRET_END_TEXT_PAYLOAD"],
+  );
+
+  const mismatch = transportFixture();
+  mismatch.start.repository.id = "SECRET_REPOSITORY_ID";
+  expectCode(
+    await observePlanning(expectedEnvelope(), { transport: mismatch.transport }),
+    "REPOSITORY_ID_MISMATCH",
+    ["SECRET_REPOSITORY_ID", "R_repo"],
+  );
 });
 
 test("end closure reruns duplicate and ambiguity checks before drift", async () => {


### PR DESCRIPTION
## Summary

- observe the five approved GitHub Project field-value variants through their
  variant-specific minimal projections;
- exhaust outer field-value plus nested User and Label pagination at both
  observation endpoints;
- preserve canonical ordering, redacted fail-closed diagnostics, exact
  repository/type and planning-identity binding, and query-only authority.

## Root cause

The observer required every Project field value to implement
`ProjectV2ItemFieldValueCommon`, although GitHub User, Repository, and Label
values expose their required members directly.

## Verification

- `make verify` — pass: 38 branch-scope, 19 Implementation-Pack, 73 planning
  tests;
- planning suite repeated with the same `73/73` result;
- independent Review B — pass after `RB142-01` remediation `1/1` and bounded
  re-review `1/1`;
- live read-only #128 replay — `plan-status-only`, `Backlog`,
  `authorityEffect: "none"`.

Closes #142

## Implementation Pack
### Authority bindings
- Work item: `#142`
- Requirements: `sha256:0ff5e0ff5d92bb48d866ba4e5fb82e5a422ee0e829a6529d0df863853254be14`
- Delivery authority: `BA-142-01; OVR-142-01; OVR-142-02; OVR-142-03`
- Review B: `RB142-01 closed; remediation-count:1; re-review-count:1`

### Changed boundaries
- `utl/gh/planning-github-observer.mjs`: variant-specific value observation, nested pagination, canonicalization, repository type/ID binding, and fail-closed validation.
- `utl/gh/planning-github-observer.test.mjs`: mixed, per-variant, pagination, malformed, duplicate, drift, redaction, authority, and repository-type regressions.
- `utl/gh/RUNBOOK.md`: complete observed connections and endpoint semantics.

### Decisions and failure behavior
- User and Label values are re-addressed by exact outer Edge position and revalidated by cursor, variant, and `field.id`; `fieldValueByName` and synthetic identities are rejected.
- Only User, Repository, Label, Text, and SingleSelect are supported; unknown or malformed variants fail with registered redacted diagnostics.
- Semantic projections and nested provider IDs are canonically sorted; incomplete/capped pagination, duplicates, identity mismatch, and drift fail closed.
- Repository binding requires exact provider type `Repository` before exact ID comparison at both endpoints.

### Acceptance evidence
- AC-01: `FIELD_VALUE_SELECTION`, `normalizeFieldValues`; per-variant and mixed-closure tests.
- AC-02: `exhaustFieldValues`, `exhaustNestedMembers`; start/end outer/User/Label pagination tests.
- AC-03: `observePlanning`, `validateClosure`, repository type regression, and complete identity/option tests.
- AC-04: `memberIds`, `closureSummary`, and independent top-level/User/Label permutation tests.
- AC-05: malformed/unknown, pagination, limit, duplicate, drift, locator, identity, and redaction tests.
- AC-06: query-only `QUERY_DOCUMENTS` and read-only export/CLI authority tests.
- AC-07: observer `26/26`; complete planning suite `73/73` twice.
- AC-08: live read-only receipt `sha256:bbc9b75d24bf04020b3d6d7c217ffa987a022f6944c4de48c43392388cb56a40`.

### Verification and candidate
- Candidate identity: `source-set:observer=sha256:0c68ce57e1290f560d29bc67bc8bc90476214e67c2d429b9365cfa3190de9851;tests=sha256:bd515a0a452497ea74d1a02c8138bf450796d6de23ad0477253fff955dc0dc5f;runbook=sha256:f4e986f7f3e1d3a71e48fafee332460c850b647328c5329d19925ff39038c10a`
- Verification: `make verify` — pass (`38 + 19 + 73`).
- Verification: `make planning-contract-test` twice — pass (`73/73` each).
- Verification: Review B — pass; `RB142-01` closed within one remediation and one bounded re-review.
- Verification: live #128 replay — pass; fingerprint `e7caab6ddb3d946a4328ec97844e3e00ef294812f0cf05ad8e3654fe55bcb7c0`.

### Residual risks and follow-ups
- A future unsupported provider variant intentionally blocks until separately scoped.
- Commit, Publication Intent, push, PR creation, Issue `In review`, merge, and final PO acceptance remain separately gated.
