### PR TITLE
Govern GitHub label taxonomy

### DIFF
--- a/.github/agents/ai4x.agent.md
+++ b/.github/agents/ai4x.agent.md
@@ -33,11 +33,11 @@ This file is the canonical agent definition for repository-wide instructions.
 - Delegate domain work to specialist agents; do not perform specialist work by default.
 - Enforce stage sequencing and artifact completeness before progression.
 - Escalate unresolved conflicts to explicit decision questions with a concrete expert recommendation and rationale. Never present open questions without a recommendation.
-- When a PO-approved roadmap identifies a coherent planned Epic, the Tech Lead may create an early GitHub Issue with label `epic` before the Requirements Pack is complete.
+- When a PO-approved roadmap identifies a coherent planned Epic, the Tech Lead may create an early GitHub Issue with label `level:epic` before the Requirements Pack is complete.
 - An early Epic container must disclose its gate facts using the canonical Epic Gate Facts Template in `adm/gdl/planning-workflow.md`. Its existence, label, parent relationship, or `Refinement` status never grants implementation authority.
 - After the PO approves an Epic's Requirements Pack, ensure that the Epic Issue contains the approved pack and delete any originating PBL entry.
 - Decompose approved Epics into Stories (GitHub Issues) and present the decomposition to the PO for approval.
-- Create approved PR-sized Stories as native GitHub Sub-Issues of their Epic with label `story`.
+- Create approved PR-sized Stories as native GitHub Sub-Issues of their Epic with label `level:story`.
 - The development workflow (Stages 1-10) executes per Story, not per Epic.
 - Own branch lifecycle: create topic branches for Stories, ensure PRs are linked to Story Issues, and decide merge readiness per `crp/gov/prc/workflow.md` (Branching and Merge Rule).
 - The Tech Lead is the PO's single point of contact. Internal specialist consultation is at the Tech Lead's discretion but the PO always receives a consolidated recommendation, not raw specialist output.

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ FISH_COMPLETION_DIR ?= $(PREFIX)/share/fish/vendor_completions.d
 
 CONFIG_MODE ?= keep
 
-.PHONY: install install-user-config uninstall clean verify licensing-check branch-scope-test implementation-pack-test planning-contract-test test
+.PHONY: install install-user-config uninstall clean verify licensing-check repo-metadata-test branch-scope-test implementation-pack-test planning-contract-test test
 
 install:
 	@command -v node >/dev/null 2>&1 || { echo '[ai4x] ERROR node is required but not found in PATH' >&2; exit 1; }
@@ -78,6 +78,7 @@ verify:
 	@git ls-files --error-unmatch cli/src/lib/.gitkeep >/dev/null 2>&1 || { echo '[ai4x] ERROR not tracked: cli/src/lib/.gitkeep' >&2; exit 2; }
 	@git ls-files --error-unmatch cli/tst/.gitkeep >/dev/null 2>&1 || { echo '[ai4x] ERROR not tracked: cli/tst/.gitkeep' >&2; exit 2; }
 	@$(MAKE) --no-print-directory licensing-check
+	@$(MAKE) --no-print-directory repo-metadata-test
 	@bash utl/gh/repo-metadata.sh --check-local
 	@$(MAKE) --no-print-directory branch-scope-test
 	@$(MAKE) --no-print-directory implementation-pack-test
@@ -87,6 +88,10 @@ verify:
 licensing-check:
 	@echo '[ai4x] verify: checking path-based licensing and attribution'
 	@bash utl/licensing/verify.sh
+
+repo-metadata-test:
+	@echo '[ai4x] verify: checking repository metadata contract'
+	@node --test utl/gh/repo-labels.test.mjs
 
 branch-scope-test:
 	@echo '[ai4x] verify: checking branch and pull-request scope contract'

--- a/utl/gh/RUNBOOK.md
+++ b/utl/gh/RUNBOOK.md
@@ -2,11 +2,11 @@
 
 ## Purpose
 
-Keep the GitHub repository About and Topics reproducible from versioned local metadata.
+Keep the GitHub repository About, Topics, and complete label taxonomy reproducible from versioned local metadata.
 
 ## Source of Truth
 
-`utl/gh/repo-metadata.yaml` — all intended repository metadata is declared here.
+`utl/gh/repo-metadata.yaml` — all intended repository metadata is declared here. Label colors are declared once per taxonomy axis so every label in that axis remains visually consistent; an approved visual exception must be an explicit per-label override.
 
 ## Commands
 
@@ -25,14 +25,17 @@ bash ./utl/gh/repo-metadata.sh --apply
 
 1. Keep `utl/gh/repo-metadata.yaml` in sync with intended GitHub metadata.
 2. Run `--check-local` before finishing metadata-related changes.
-3. Run `--check` when remote drift must be validated.
+3. Run `--check` when remote drift must be validated. It fails when GitHub authentication is unavailable; it never degrades to a local-only success.
 4. Use `--apply` when metadata updates are intentional and the remote repository must be reconciled.
 5. Do not finish metadata changes while intended local metadata and remote GitHub metadata still differ.
+6. Label apply may create declared labels and update their metadata. It fails closed when GitHub contains an undeclared label and never deletes labels; deletion requires a separate exact PO-approved action.
+7. Remote check and apply resolve their sole `owner/repository` target from this checkout's `origin`; caller working directory and `GH_REPO` cannot redirect it.
+8. Apply skips metadata that already matches. If a provider write fails after earlier writes, the diagnostic lists completed operations and requires a fresh `--check` before recovery.
 
 ## When to Use
 
 The Tech Lead triggers metadata operations when:
-- Repository About or Topics need to change
+- Repository About, Topics, or labels need to change
 - `make verify` reports a metadata drift
 - A Story or chore explicitly requires metadata reconciliation
 

--- a/utl/gh/repo-labels.mjs
+++ b/utl/gh/repo-labels.mjs
@@ -1,0 +1,144 @@
+const AXES = Object.freeze(["level", "kind", "topic", "aspect", "signal"]);
+const SLUG_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+const COLOR_PATTERN = /^[0-9A-F]{6}$/;
+const MAX_DESCRIPTION_LENGTH = 100;
+
+function isRecord(value) {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function requireClosedKeys(value, expected, subject) {
+  const actual = Object.keys(value).sort();
+  const wanted = [...expected].sort();
+  if (JSON.stringify(actual) !== JSON.stringify(wanted)) {
+    throw new Error(`${subject} keys must be exactly: ${wanted.join(", ")}`);
+  }
+}
+
+export function labelRecordsFromConfig(config) {
+  if (!isRecord(config)) {
+    throw new Error("labels must be a map");
+  }
+  requireClosedKeys(config, AXES, "label axes");
+
+  const records = [];
+  for (const axis of AXES) {
+    const entry = config[axis];
+    if (!isRecord(entry)) {
+      throw new Error(`label axis '${axis}' must be a map`);
+    }
+    const entryKeys = Object.keys(entry);
+    if (!entryKeys.includes("color") || !entryKeys.includes("values") || entryKeys.some((key) => !["color", "values", "overrides"].includes(key))) {
+      throw new Error(`label axis '${axis}' keys must be color, values, and optional overrides`);
+    }
+
+    if (typeof entry.color !== "string" || !COLOR_PATTERN.test(entry.color)) {
+      throw new Error(`label axis '${axis}' color must be six uppercase hexadecimal characters`);
+    }
+    if (!isRecord(entry.values) || Object.keys(entry.values).length === 0) {
+      throw new Error(`label axis '${axis}' values must be a non-empty map`);
+    }
+    const overrides = entry.overrides ?? {};
+    if (!isRecord(overrides)) {
+      throw new Error(`label axis '${axis}' overrides must be a map`);
+    }
+    for (const [slug, color] of Object.entries(overrides)) {
+      if (!Object.hasOwn(entry.values, slug)) {
+        throw new Error(`label axis '${axis}' overrides unknown value '${slug}'`);
+      }
+      if (typeof color !== "string" || !COLOR_PATTERN.test(color)) {
+        throw new Error(`label '${axis}:${slug}' override must be six uppercase hexadecimal characters`);
+      }
+      if (color === entry.color) {
+        throw new Error(`label '${axis}:${slug}' override must differ from its axis color`);
+      }
+    }
+
+    for (const [slug, description] of Object.entries(entry.values)) {
+      if (!SLUG_PATTERN.test(slug)) {
+        throw new Error(`label axis '${axis}' contains invalid value '${slug}'`);
+      }
+      if (typeof description !== "string" || description.trim() !== description || description.length === 0) {
+        throw new Error(`label '${axis}:${slug}' requires a non-empty, trimmed description`);
+      }
+      if (description.length > MAX_DESCRIPTION_LENGTH) {
+        throw new Error(`label '${axis}:${slug}' description exceeds ${MAX_DESCRIPTION_LENGTH} characters`);
+      }
+      records.push(Object.freeze({ name: `${axis}:${slug}`, color: overrides[slug] ?? entry.color, description }));
+    }
+  }
+
+  return Object.freeze(records.sort((left, right) => left.name.localeCompare(right.name)));
+}
+
+function normalizeRemoteRecords(records) {
+  if (!Array.isArray(records)) {
+    throw new Error("remote labels must be an array");
+  }
+  const byName = new Map();
+  for (const record of records) {
+    if (!isRecord(record) || typeof record.name !== "string" || record.name.length === 0) {
+      throw new Error("remote label requires a non-empty name");
+    }
+    const color = typeof record.color === "string" ? record.color.toUpperCase() : "";
+    if (!COLOR_PATTERN.test(color)) {
+      throw new Error(`remote label '${record.name}' has an invalid color`);
+    }
+    const description = record.description ?? "";
+    if (typeof description !== "string") {
+      throw new Error(`remote label '${record.name}' has an invalid description`);
+    }
+    if (byName.has(record.name)) {
+      throw new Error(`remote labels contain duplicate '${record.name}'`);
+    }
+    byName.set(record.name, Object.freeze({ name: record.name, color, description }));
+  }
+  return byName;
+}
+
+export function diffLabelRecords(expected, observed) {
+  if (!Array.isArray(expected)) {
+    throw new Error("expected labels must be an array");
+  }
+  const expectedByName = new Map(expected.map((record) => [record.name, record]));
+  if (expectedByName.size !== expected.length) {
+    throw new Error("expected labels contain duplicate names");
+  }
+  const observedByName = normalizeRemoteRecords(observed);
+
+  const missing = [...expectedByName.keys()].filter((name) => !observedByName.has(name)).sort();
+  const extra = [...observedByName.keys()].filter((name) => !expectedByName.has(name)).sort();
+  const mismatched = [];
+  for (const [name, wanted] of expectedByName) {
+    const actual = observedByName.get(name);
+    if (!actual) continue;
+    const fields = [];
+    if (actual.color !== wanted.color) fields.push("color");
+    if (actual.description !== wanted.description) fields.push("description");
+    if (fields.length > 0) mismatched.push(Object.freeze({ name, fields: Object.freeze(fields) }));
+  }
+  mismatched.sort((left, right) => left.name.localeCompare(right.name));
+
+  return Object.freeze({
+    missing: Object.freeze(missing),
+    extra: Object.freeze(extra),
+    mismatched: Object.freeze(mismatched),
+  });
+}
+
+export function planLabelReconciliation(expected, observed) {
+  const diff = diffLabelRecords(expected, observed);
+  if (diff.extra.length > 0) {
+    return Object.freeze({ ok: false, reason: "undeclared-labels", diff, operations: Object.freeze([]) });
+  }
+
+  const expectedByName = new Map(expected.map((record) => [record.name, record]));
+  const operations = [
+    ...diff.missing.map((name) => Object.freeze({ action: "create", label: expectedByName.get(name) })),
+    ...diff.mismatched.map(({ name }) => Object.freeze({ action: "update", label: expectedByName.get(name) })),
+  ].sort((left, right) => left.label.name.localeCompare(right.label.name));
+
+  return Object.freeze({ ok: true, reason: null, diff, operations: Object.freeze(operations) });
+}
+
+export const LABEL_AXES = AXES;

--- a/utl/gh/repo-labels.test.mjs
+++ b/utl/gh/repo-labels.test.mjs
@@ -1,0 +1,379 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+import { loadMetadata } from "./repo-metadata.mjs";
+import {
+  LABEL_AXES,
+  diffLabelRecords,
+  labelRecordsFromConfig,
+  planLabelReconciliation,
+} from "./repo-labels.mjs";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(HERE, "..", "..");
+const TARGET = "normenmueller/ai4X";
+
+const FAKE_GH = `#!/usr/bin/env node
+import { appendFileSync, readFileSync, writeFileSync } from "node:fs";
+
+const fixture = JSON.parse(readFileSync(process.env.FAKE_GH_FIXTURE, "utf8"));
+const args = process.argv.slice(2);
+if (args[0] === "auth" && args[1] === "status") process.exit(0);
+if (args[0] === "repo") {
+  process.stderr.write("unbound repo lookup is forbidden\\n");
+  process.exit(70);
+}
+if (args[0] !== "api") process.exit(71);
+
+const methodIndex = args.indexOf("-X");
+const method = methodIndex === -1 ? "GET" : args[methodIndex + 1];
+const endpoint = args.find((arg) => arg.startsWith("repos/"));
+if (!endpoint) process.exit(72);
+const write = method !== "GET";
+appendFileSync(process.env.FAKE_GH_LOG, JSON.stringify({ cwd: process.cwd(), method, endpoint, args, write }) + "\\n");
+
+if (write) {
+  const counterPath = process.env.FAKE_GH_COUNTER;
+  const count = Number(readFileSync(counterPath, "utf8")) + 1;
+  writeFileSync(counterPath, String(count));
+  if (fixture.failWriteAt === count) {
+    process.stderr.write("synthetic write failure\\n");
+    process.exit(73);
+  }
+  process.stdout.write("{}\\n");
+  process.exit(0);
+}
+
+if (endpoint === \`repos/\${fixture.target}\`) {
+  process.stdout.write(fixture.about + "\\n");
+  process.exit(0);
+}
+if (endpoint === \`repos/\${fixture.target}/topics\`) {
+  process.stdout.write(fixture.topics.join("\\n") + "\\n");
+  process.exit(0);
+}
+if (endpoint === \`repos/\${fixture.target}/labels?per_page=100\`) {
+  if (fixture.labelReadFailure) {
+    process.stderr.write("synthetic label read failure\\n");
+    process.exit(74);
+  }
+  process.stdout.write(fixture.malformedLabels ? "not-json" : JSON.stringify(fixture.labelPages));
+  process.exit(0);
+}
+process.stderr.write(\`unexpected endpoint: \${endpoint}\\n\`);
+process.exit(75);
+`;
+
+function withFakeProvider(overrides, assertion) {
+  const root = mkdtempSync(path.join(os.tmpdir(), "ai4x-repo-metadata-"));
+  const bin = path.join(root, "bin");
+  const foreignCwd = path.join(root, "foreign");
+  const fixturePath = path.join(root, "fixture.json");
+  const logPath = path.join(root, "calls.jsonl");
+  const counterPath = path.join(root, "counter");
+  mkdirSync(bin);
+  mkdirSync(foreignCwd);
+  const ghPath = path.join(bin, "gh");
+  writeFileSync(ghPath, FAKE_GH);
+  chmodSync(ghPath, 0o755);
+  writeFileSync(logPath, "");
+  writeFileSync(counterPath, "0");
+
+  const metadata = loadMetadata();
+  const labels = metadata.labels.map((label) => ({ ...label }));
+  const fixture = {
+    target: TARGET,
+    about: metadata.about,
+    topics: metadata.topics,
+    labelPages: [labels],
+    malformedLabels: false,
+    labelReadFailure: false,
+    failWriteAt: null,
+    ...overrides,
+  };
+  writeFileSync(fixturePath, JSON.stringify(fixture));
+
+  try {
+    const run = (mode) => spawnSync("node", [path.join(HERE, "repo-metadata.mjs"), mode], {
+      cwd: foreignCwd,
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        PATH: `${bin}:${process.env.PATH}`,
+        GH_REPO: "attacker/ai4X",
+        FAKE_GH_FIXTURE: fixturePath,
+        FAKE_GH_LOG: logPath,
+        FAKE_GH_COUNTER: counterPath,
+      },
+    });
+    const calls = () => readFileSync(logPath, "utf8")
+      .trim()
+      .split("\n")
+      .filter(Boolean)
+      .map((line) => JSON.parse(line));
+    assertion({ run, calls, metadata, labels, foreignCwd });
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+}
+
+function config() {
+  return Object.fromEntries(LABEL_AXES.map((axis, index) => [
+    axis,
+    {
+      color: ["D8C7F0", "B9DCF2", "BFE3D0", "F4D0AE", "EDB8C4"][index],
+      values: { sample: `${axis} description` },
+    },
+  ]));
+}
+
+test("loads the checked-in repository metadata contract", () => {
+  const result = spawnSync("node", [path.join(HERE, "repo-metadata.mjs"), "--check-local"], {
+    encoding: "utf8",
+  });
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /local metadata contract: ok/);
+});
+
+test("remote check fails closed when GitHub authentication is unavailable", () => {
+  const ghConfig = mkdtempSync(path.join(os.tmpdir(), "ai4x-gh-auth-"));
+  try {
+    const result = spawnSync("node", [path.join(HERE, "repo-metadata.mjs"), "--check"], {
+      encoding: "utf8",
+      env: { ...process.env, GH_CONFIG_DIR: ghConfig, GH_TOKEN: "", GITHUB_TOKEN: "" },
+    });
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /gh auth is required for remote drift check/);
+    assert.doesNotMatch(result.stdout, /remote metadata check: ok/);
+  } finally {
+    rmSync(ghConfig, { recursive: true, force: true });
+  }
+});
+
+test("expands one color per closed taxonomy axis", () => {
+  const records = labelRecordsFromConfig(config());
+  assert.deepEqual(records.map(({ name }) => name), [
+    "aspect:sample",
+    "kind:sample",
+    "level:sample",
+    "signal:sample",
+    "topic:sample",
+  ]);
+  for (const record of records) {
+    const axis = record.name.split(":", 1)[0];
+    assert.equal(record.color, config()[axis].color);
+  }
+});
+
+test("applies an explicit per-label color override without changing its axis peers", () => {
+  const overridden = config();
+  overridden.kind.values.bug = "bug description";
+  overridden.kind.overrides = { bug: "E85D68" };
+  const records = labelRecordsFromConfig(overridden);
+
+  assert.equal(records.find(({ name }) => name === "kind:bug").color, "E85D68");
+  assert.equal(records.find(({ name }) => name === "kind:sample").color, "B9DCF2");
+});
+
+test("rejects open, incomplete, and malformed label contracts", () => {
+  const missing = config();
+  delete missing.signal;
+  assert.throws(() => labelRecordsFromConfig(missing), /label axes keys must be exactly/);
+
+  const extra = config();
+  extra.other = { color: "ABCDEF", values: { sample: "other description" } };
+  assert.throws(() => labelRecordsFromConfig(extra), /label axes keys must be exactly/);
+
+  const lowercase = config();
+  lowercase.kind.color = "b9dcf2";
+  assert.throws(() => labelRecordsFromConfig(lowercase), /uppercase hexadecimal/);
+
+  const unknownEntryKey = config();
+  unknownEntryKey.kind.exception = "E85D68";
+  assert.throws(() => labelRecordsFromConfig(unknownEntryKey), /keys must be color, values, and optional overrides/);
+
+  const unknownOverride = config();
+  unknownOverride.kind.overrides = { bug: "E85D68" };
+  assert.throws(() => labelRecordsFromConfig(unknownOverride), /overrides unknown value/);
+
+  const lowercaseOverride = config();
+  lowercaseOverride.kind.overrides = { sample: "e85d68" };
+  assert.throws(() => labelRecordsFromConfig(lowercaseOverride), /override must be six uppercase hexadecimal/);
+
+  const redundantOverride = config();
+  redundantOverride.kind.overrides = { sample: redundantOverride.kind.color };
+  assert.throws(() => labelRecordsFromConfig(redundantOverride), /override must differ/);
+
+  const invalidSlug = config();
+  invalidSlug.topic.values["Not Valid"] = "description";
+  assert.throws(() => labelRecordsFromConfig(invalidSlug), /invalid value/);
+
+  const paddedDescription = config();
+  paddedDescription.aspect.values.sample = " padded ";
+  assert.throws(() => labelRecordsFromConfig(paddedDescription), /non-empty, trimmed description/);
+
+  const longDescription = config();
+  longDescription.level.values.sample = "x".repeat(101);
+  assert.throws(() => labelRecordsFromConfig(longDescription), /exceeds 100/);
+});
+
+test("detects missing, undeclared, and mismatched remote labels", () => {
+  const expected = labelRecordsFromConfig(config());
+  const observed = expected.slice(1).map((record) => ({ ...record, color: record.color.toLowerCase() }));
+  observed[0] = { ...observed[0], description: "changed" };
+  observed.push({ name: "legacy:label", color: "ABCDEF", description: null });
+
+  assert.deepEqual(diffLabelRecords(expected, observed), {
+    missing: [expected[0].name],
+    extra: ["legacy:label"],
+    mismatched: [{ name: observed[0].name, fields: ["description"] }],
+  });
+});
+
+test("refuses undeclared labels without producing deletion operations", () => {
+  const expected = labelRecordsFromConfig(config());
+  const observed = [...expected, { name: "legacy:label", color: "ABCDEF", description: "legacy" }];
+  const plan = planLabelReconciliation(expected, observed);
+
+  assert.equal(plan.ok, false);
+  assert.equal(plan.reason, "undeclared-labels");
+  assert.deepEqual(plan.operations, []);
+});
+
+test("plans only deterministic create and update operations", () => {
+  const expected = labelRecordsFromConfig(config());
+  const observed = expected.slice(1).map((record, index) => index === 0
+    ? { ...record, color: "ABCDEF" }
+    : record);
+  const plan = planLabelReconciliation(expected, observed);
+
+  assert.equal(plan.ok, true);
+  assert.deepEqual(plan.operations.map(({ action, label }) => [action, label.name]), [
+    ["create", expected[0].name],
+    ["update", observed[0].name],
+  ]);
+  assert.ok(plan.operations.every(({ action }) => action === "create" || action === "update"));
+});
+
+test("remote check binds every provider call to origin despite foreign cwd and GH_REPO", () => {
+  withFakeProvider({}, ({ run, calls, foreignCwd }) => {
+    const result = run("--check");
+    assert.equal(result.status, 0, result.stderr);
+    assert.notEqual(foreignCwd, REPO_ROOT);
+    assert.ok(calls().length >= 3);
+    assert.ok(calls().every((call) => call.cwd === REPO_ROOT));
+    assert.ok(calls().every((call) => call.endpoint.startsWith(`repos/${TARGET}`)));
+    assert.doesNotMatch(result.stderr, /unbound repo lookup/);
+  });
+});
+
+test("remote check consumes complete multi-page label evidence", () => {
+  const metadata = loadMetadata();
+  const labels = metadata.labels.map((label) => ({ ...label }));
+  withFakeProvider({ labelPages: [labels.slice(0, 7), labels.slice(7, 14), labels.slice(14)] }, ({ run }) => {
+    const result = run("--check");
+    assert.equal(result.status, 0, result.stderr);
+  });
+});
+
+test("remote check reports every label drift class without mutation", () => {
+  const metadata = loadMetadata();
+  const labels = metadata.labels.map((label) => ({ ...label }));
+  const cases = [
+    ["missing", labels.slice(1), /remote labels missing/],
+    ["extra", [...labels, { name: "legacy:label", color: "ABCDEF", description: "legacy" }], /undeclared remote labels/],
+    ["name", [{ ...labels[0], name: "renamed:label" }, ...labels.slice(1)], /remote labels missing.*undeclared remote labels/s],
+    ["color", [{ ...labels[0], color: "ABCDEF" }, ...labels.slice(1)], /metadata mismatch.*color/],
+    ["description", [{ ...labels[0], description: "changed" }, ...labels.slice(1)], /metadata mismatch.*description/],
+  ];
+
+  for (const [name, remoteLabels, diagnostic] of cases) {
+    withFakeProvider({ labelPages: [remoteLabels] }, ({ run, calls }) => {
+      const result = run("--check");
+      assert.equal(result.status, 1, `${name}: ${result.stderr}`);
+      assert.match(result.stderr, diagnostic, name);
+      assert.equal(calls().filter(({ write }) => write).length, 0, name);
+    });
+  }
+});
+
+test("remote check fails closed on malformed and inaccessible label evidence", () => {
+  for (const [overrides, diagnostic] of [
+    [{ malformedLabels: true }, /failed to parse labels/],
+    [{ labelReadFailure: true }, /failed to read labels.*synthetic label read failure/],
+  ]) {
+    withFakeProvider(overrides, ({ run, calls }) => {
+      const result = run("--check");
+      assert.equal(result.status, 1);
+      assert.match(result.stderr, diagnostic);
+      assert.equal(calls().filter(({ write }) => write).length, 0);
+    });
+  }
+});
+
+test("apply performs no writes when any undeclared label exists", () => {
+  const metadata = loadMetadata();
+  const labels = [
+    ...metadata.labels.map((label) => ({ ...label })),
+    { name: "legacy:label", color: "ABCDEF", description: "legacy" },
+  ];
+  withFakeProvider({ labelPages: [labels], about: "also changed", topics: ["also-changed"] }, ({ run, calls }) => {
+    const result = run("--apply");
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /refusing to delete undeclared remote labels/);
+    assert.equal(calls().filter(({ write }) => write).length, 0);
+  });
+});
+
+test("apply emits only required PATCH, PUT, and POST operations against the bound target", () => {
+  const metadata = loadMetadata();
+  const labels = metadata.labels.map((label) => ({ ...label }));
+  const changed = labels.slice(1);
+  changed[0] = { ...changed[0], color: "ABCDEF" };
+  withFakeProvider({ labelPages: [changed], about: "changed", topics: ["changed"] }, ({ run, calls }) => {
+    const result = run("--apply");
+    assert.equal(result.status, 0, result.stderr);
+    const writes = calls().filter(({ write }) => write);
+    assert.deepEqual(writes.map(({ method, endpoint }) => [method, endpoint]), [
+      ["PATCH", `repos/${TARGET}`],
+      ["PUT", `repos/${TARGET}/topics`],
+      ["POST", `repos/${TARGET}/labels`],
+      ["PATCH", `repos/${TARGET}/labels/${encodeURIComponent(labels[1].name)}`],
+    ]);
+    assert.ok(writes.every(({ method }) => method !== "DELETE"));
+    assert.ok(writes.every(({ cwd }) => cwd === REPO_ROOT));
+  });
+});
+
+test("apply avoids no-op writes when provider metadata already matches", () => {
+  withFakeProvider({}, ({ run, calls }) => {
+    const result = run("--apply");
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(result.stdout, /applied normenmueller\/ai4X \(0 metadata changes\)/);
+    assert.equal(calls().filter(({ write }) => write).length, 0);
+  });
+});
+
+test("apply halts after provider failure and reports completed operations", () => {
+  const metadata = loadMetadata();
+  const labels = metadata.labels.map((label) => ({ ...label }));
+  const changed = labels.slice(1);
+  changed[0] = { ...changed[0], color: "ABCDEF" };
+  changed[1] = { ...changed[1], description: "changed" };
+  withFakeProvider({ labelPages: [changed], failWriteAt: 2 }, ({ run, calls }) => {
+    const result = run("--apply");
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /synthetic write failure/);
+    assert.match(result.stderr, new RegExp(`completed: label:create:${labels[0].name}`));
+    assert.match(result.stderr, /rerun --check before recovery/);
+    const writes = calls().filter(({ write }) => write);
+    assert.equal(writes.length, 2);
+    assert.equal(writes[0].method, "POST");
+    assert.equal(writes[1].method, "PATCH");
+    assert.ok(writes.every(({ method }) => method !== "DELETE"));
+  });
+});

--- a/utl/gh/repo-metadata.mjs
+++ b/utl/gh/repo-metadata.mjs
@@ -3,21 +3,16 @@ import fs from "node:fs";
 import path from "node:path";
 import { spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
+import { diffLabelRecords, labelRecordsFromConfig, planLabelReconciliation } from "./repo-labels.mjs";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const REPO_ROOT = path.resolve(__dirname, "..", "..");
 const METADATA_FILE = path.join(__dirname, "repo-metadata.yaml");
-const REPO_METADATA_VERSION = "0.1.0";
-
-const mode = process.argv[2] ?? "--check";
-if (!["--check", "--check-local", "--apply"].includes(mode)) {
-  process.stderr.write("[gh|error]: usage: --check | --check-local | --apply\n");
-  process.exit(2);
-}
+const REPO_METADATA_VERSION = "0.2.0";
 
 function runGh(args) {
-  return spawnSync("gh", args, { encoding: "utf8" });
+  return spawnSync("gh", args, { encoding: "utf8", cwd: REPO_ROOT });
 }
 
 function runGit(args) {
@@ -152,7 +147,7 @@ function validateRepoEntry(id, entry) {
   return true;
 }
 
-function loadMetadata() {
+export function loadMetadata() {
   if (!fs.existsSync(METADATA_FILE)) {
     throw new Error(`missing metadata file: ${METADATA_FILE}`);
   }
@@ -169,7 +164,7 @@ function loadMetadata() {
   if (!validateRepoEntry(cfg.repo, cfg)) {
     throw new Error("metadata validation failed");
   }
-  return cfg;
+  return { ...cfg, labels: labelRecordsFromConfig(cfg.labels) };
 }
 
 function normalizeTopics(topics) {
@@ -183,6 +178,57 @@ function topicsEqual(a, b) {
   const right = normalizeTopics(b);
   if (left.length !== right.length) return false;
   return left.every((topic, idx) => topic === right[idx]);
+}
+
+function readRemoteLabels(target) {
+  const output = runGh(["api", "--paginate", "--slurp", `repos/${target}/labels?per_page=100`]);
+  if (output.status !== 0) {
+    throw new Error(`failed to read labels for ${target}: ${output.stderr.trim()}`);
+  }
+  let pages;
+  try {
+    pages = JSON.parse(output.stdout);
+  } catch {
+    throw new Error(`failed to parse labels for ${target}`);
+  }
+  if (!Array.isArray(pages) || !pages.every(Array.isArray)) {
+    throw new Error(`labels for ${target} are not a paginated array`);
+  }
+  return pages.flat();
+}
+
+function readRemoteState(target) {
+  const aboutOut = runGh(["api", `repos/${target}`, "--jq", ".description // \"\""]);
+  if (aboutOut.status !== 0) {
+    throw new Error(`failed to read description for ${target}: ${aboutOut.stderr.trim()}`);
+  }
+  const topicsOut = runGh(["api", `repos/${target}/topics`, "--jq", ".names[]"]);
+  if (topicsOut.status !== 0) {
+    throw new Error(`failed to read topics for ${target}: ${topicsOut.stderr.trim()}`);
+  }
+  const topics = topicsOut.stdout
+    .split("\n")
+    .map((topic) => topic.trim())
+    .filter((topic) => topic.length > 0);
+  return { about: aboutOut.stdout.trim(), topics, labels: readRemoteLabels(target) };
+}
+
+function reportLabelDiff(diff, target) {
+  let ok = true;
+  if (diff.missing.length > 0) {
+    fail(`remote labels missing for ${target}: ${diff.missing.join(", ")}`);
+    ok = false;
+  }
+  if (diff.extra.length > 0) {
+    fail(`undeclared remote labels for ${target}: ${diff.extra.join(", ")}`);
+    ok = false;
+  }
+  if (diff.mismatched.length > 0) {
+    const details = diff.mismatched.map(({ name, fields }) => `${name}(${fields.join("+")})`);
+    fail(`remote label metadata mismatch for ${target}: ${details.join(", ")}`);
+    ok = false;
+  }
+  return ok;
 }
 
 function resolveRepoRefFromGit() {
@@ -207,8 +253,7 @@ function ghAvailable() {
   return probe.status === 0;
 }
 
-function checkLocalMetadata(metadata) {
-  const repoRef = resolveRepoRefFromGit();
+function checkLocalMetadata(metadata, repoRef) {
   if (!repoRef) {
     process.stdout.write("[gh|warn]: cannot derive owner/repo from git remote; local-only checks applied\n");
     return true;
@@ -220,98 +265,109 @@ function checkLocalMetadata(metadata) {
   return true;
 }
 
-function checkRemote(metadata) {
+function checkRemote(metadata, target) {
   if (!ghAvailable()) {
-    process.stdout.write("[gh|warn]: gh auth is unavailable; remote drift check skipped\n");
-    return true;
+    return fail("gh auth is required for remote drift check; use --check-local for offline validation");
   }
-  const repoRef = runGh(["repo", "view", "--json", "nameWithOwner", "--jq", ".nameWithOwner"]);
-  if (repoRef.status !== 0) {
-    return fail(`failed to determine active repo with gh: ${repoRef.stderr.trim()}`);
+  let remote;
+  try {
+    remote = readRemoteState(target);
+  } catch (error) {
+    return fail(error instanceof Error ? error.message : String(error));
   }
-  const target = repoRef.stdout.trim();
-
-  const descOut = runGh(["api", `repos/${target}`, "--jq", ".description // \"\""]);
-  if (descOut.status !== 0) {
-    return fail(`failed to read description for ${target}: ${descOut.stderr.trim()}`);
-  }
-  const remoteAbout = descOut.stdout.trim();
   let ok = true;
-  if (remoteAbout !== metadata.about) {
+  if (remote.about !== metadata.about) {
     ok = fail(`remote about mismatch for ${target}`) && ok;
   }
-
-  const topicsOut = runGh(["api", `repos/${target}/topics`, "--jq", ".names[]"]);
-  if (topicsOut.status !== 0) {
-    return fail(`failed to read topics for ${target}: ${topicsOut.stderr.trim()}`) && ok;
-  }
-  const remoteTopics = topicsOut.stdout
-    .split("\n")
-    .map((topic) => topic.trim())
-    .filter((topic) => topic.length > 0);
-
-  if (!topicsEqual(remoteTopics, metadata.topics)) {
+  if (!topicsEqual(remote.topics, metadata.topics)) {
     ok = fail(`remote topics mismatch for ${target}`) && ok;
+  }
+  if (!reportLabelDiff(diffLabelRecords(metadata.labels, remote.labels), target)) {
+    ok = false;
   }
   return ok;
 }
 
-function applyRemote(metadata) {
+function applyRemote(metadata, target) {
   if (!ghAvailable()) {
     process.stderr.write("[gh|error]: gh auth is required for --apply\n");
     return false;
   }
-  const repoRef = runGh(["repo", "view", "--json", "nameWithOwner", "--jq", ".nameWithOwner"]);
-  if (repoRef.status !== 0) {
-    return fail(`failed to determine active repo with gh: ${repoRef.stderr.trim()}`);
+  let remote;
+  try {
+    remote = readRemoteState(target);
+  } catch (error) {
+    return fail(error instanceof Error ? error.message : String(error));
   }
-  const target = repoRef.stdout.trim();
-
-  const descOut = runGh(["api", "-X", "PATCH", `repos/${target}`, "-f", `description=${metadata.about}`]);
-  if (descOut.status !== 0) {
-    return fail(`failed to apply description for ${target}: ${descOut.stderr.trim()}`);
-  }
-
-  const topicArgs = ["api", "-X", "PUT", `repos/${target}/topics`];
-  for (const topic of metadata.topics) {
-    topicArgs.push("-f", `names[]=${topic}`);
-  }
-  const topicsOut = runGh(topicArgs);
-  if (topicsOut.status !== 0) {
-    return fail(`failed to apply topics for ${target}: ${topicsOut.stderr.trim()}`);
+  const labelPlan = planLabelReconciliation(metadata.labels, remote.labels);
+  if (!labelPlan.ok) {
+    return fail(`refusing to delete undeclared remote labels for ${target}: ${labelPlan.diff.extra.join(", ")}`);
   }
 
-  process.stdout.write(`[gh|info]: applied ${target}\n`);
+  const operations = [];
+  if (remote.about !== metadata.about) {
+    operations.push({ name: "about:update", args: ["api", "-X", "PATCH", `repos/${target}`, "-f", `description=${metadata.about}`] });
+  }
+  if (!topicsEqual(remote.topics, metadata.topics)) {
+    const args = ["api", "-X", "PUT", `repos/${target}/topics`];
+    for (const topic of metadata.topics) args.push("-f", `names[]=${topic}`);
+    operations.push({ name: "topics:update", args });
+  }
+  for (const operation of labelPlan.operations) {
+    const { name, color, description } = operation.label;
+    const args = operation.action === "create"
+      ? ["api", "-X", "POST", `repos/${target}/labels`, "-f", `name=${name}`, "-f", `color=${color}`, "-f", `description=${description}`]
+      : ["api", "-X", "PATCH", `repos/${target}/labels/${encodeURIComponent(name)}`, "-f", `new_name=${name}`, "-f", `color=${color}`, "-f", `description=${description}`];
+    operations.push({ name: `label:${operation.action}:${name}`, args });
+  }
+
+  const completed = [];
+  for (const operation of operations) {
+    const output = runGh(operation.args);
+    if (output.status !== 0) {
+      const receipt = completed.length > 0 ? completed.join(", ") : "none";
+      return fail(`operation '${operation.name}' failed for ${target}: ${output.stderr.trim()}; completed: ${receipt}; rerun --check before recovery`);
+    }
+    completed.push(operation.name);
+  }
+
+  process.stdout.write(`[gh|info]: applied ${target} (${operations.length} metadata changes)\n`);
   return true;
 }
 
-let metadata;
-try {
-  metadata = loadMetadata();
-} catch (error) {
-  process.stderr.write(`[gh|error]: ${error instanceof Error ? error.message : String(error)}\n`);
-  process.exit(1);
-}
+function main() {
+  const mode = process.argv[2] ?? "--check";
+  if (!["--check", "--check-local", "--apply"].includes(mode)) {
+    process.stderr.write("[gh|error]: usage: --check | --check-local | --apply\n");
+    process.exit(2);
+  }
 
-const localOk = checkLocalMetadata(metadata);
-if (!localOk) {
-  process.exit(1);
-}
-process.stdout.write("[gh|info]: local metadata contract: ok\n");
-
-if (mode === "--check-local") {
-  process.exit(0);
-}
-
-if (mode === "--check") {
-  if (!checkRemote(metadata)) {
+  let metadata;
+  try {
+    metadata = loadMetadata();
+  } catch (error) {
+    process.stderr.write(`[gh|error]: ${error instanceof Error ? error.message : String(error)}\n`);
     process.exit(1);
   }
-  process.stdout.write("[gh|info]: remote metadata check: ok\n");
-  process.exit(0);
+  const target = resolveRepoRefFromGit();
+  if (!checkLocalMetadata(metadata, target)) process.exit(1);
+  process.stdout.write("[gh|info]: local metadata contract: ok\n");
+
+  if (mode === "--check-local") process.exit(0);
+  if (!target) {
+    process.stderr.write("[gh|error]: exact owner/repository cannot be derived from origin\n");
+    process.exit(1);
+  }
+  if (mode === "--check") {
+    if (!checkRemote(metadata, target)) process.exit(1);
+    process.stdout.write("[gh|info]: remote metadata check: ok\n");
+    process.exit(0);
+  }
+
+  if (!applyRemote(metadata, target)) process.exit(1);
+  process.stdout.write("[gh|info]: apply completed\n");
 }
 
-if (!applyRemote(metadata)) {
-  process.exit(1);
+if (process.argv[1] && path.resolve(process.argv[1]) === __filename) {
+  main();
 }
-process.stdout.write("[gh|info]: apply completed\n");

--- a/utl/gh/repo-metadata.yaml
+++ b/utl/gh/repo-metadata.yaml
@@ -1,4 +1,4 @@
-version: 0.1.0
+version: 0.2.0
 repo: ai4X
 about: "Operating model for fit-for-purpose, consistent agent curation and explicit runtime activation"
 topics:
@@ -10,3 +10,40 @@ topics:
   - cognitive-capabilities
   - requirements-engineering
   - byoa
+labels:
+  level:
+    color: D8C7F0
+    values:
+      roadmap: "Structural projection: roadmap; native relations remain authoritative"
+      epic: "Structural projection: Epic; native Parent/Sub-Issue relations remain authoritative"
+      story: "Structural projection: Story; native Parent/Sub-Issue relations remain authoritative"
+  kind:
+    color: B9DCF2
+    overrides:
+      bug: E85D68
+    values:
+      feature: "Work kind: product, platform, or governance feature"
+      bug: "Work kind: correction of defective behavior"
+      chore: "Work kind: maintenance, housekeeping, or bounded governance work"
+      research: "Work kind: exploratory work without implementation authority"
+      planning: "Work kind: roadmap, backlog, or coordination planning"
+  topic:
+    color: BFE3D0
+    values:
+      intent-curation: "Topic: Project Intent, Needs, corpus curation, and traceability"
+      cognitive-capabilities: "Topic: cognitive Capabilities and their contracts"
+      collaboration-work: "Topic: collaboration models, roles, delegation, and work interaction"
+      governance-controls: "Topic: governance, authority, policy, and deterministic controls"
+      operations-assurance: "Topic: operational tooling, verification, evidence, and Assurance"
+      core-platform: "Topic: core product architecture, runtime, CLI, and foundational platform"
+      integrations-adapters: "Topic: host, provider, protocol, and third-party integrations or adapters"
+  aspect:
+    color: F4D0AE
+    values:
+      documentation: "Work aspect: human- or agent-facing documentation is materially affected"
+      automation: "Work aspect: repository, provider, or workflow automation is materially affected"
+  signal:
+    color: EDB8C4
+    values:
+      eyodf: "Signal: ai4X is self-applied and tested on the ai4X repository"
+      generalization: "Signal: project evidence may become reusable ai4X portfolio behavior"


### PR DESCRIPTION
## Summary

- declare the complete 19-label taxonomy in versioned repository metadata
- keep one visual color per taxonomy axis, with the approved `kind:bug` override `E85D68`
- reconcile label names, colors, and descriptions through deterministic remote checks
- create or update declared labels without ever deleting an undeclared label
- update the active Epic and Story label references

## Why

Issue #91 established a lean five-axis taxonomy but the applied GitHub state was not yet reproducible from the repository. This change makes the accepted taxonomy reviewable and drift-detectable without creating a second work-management authority.

## Safety and behavior

- The remote target is derived solely from this checkout's exact `origin`; caller working directory and `GH_REPO` cannot redirect it.
- `--check` fails when GitHub authentication or complete provider evidence is unavailable.
- Label pagination is exhausted before comparison.
- Missing, undeclared, color-drifted, and description-drifted labels fail distinctly.
- Apply pre-reads all remote metadata, blocks before mutation when undeclared labels exist, skips no-op writes, and has no DELETE path.
- If a provider write fails after earlier writes, the diagnostic records completed operations and requires a fresh `--check` before recovery.

## Review

An independent bounded review initially found target-binding, process-boundary-test, and Make `.PHONY` gaps. All three findings were remediated and independently re-reviewed as closed. Final verdict: `PASS`.

## Validation

- `node --test utl/gh/repo-labels.test.mjs` — 16/16 passing
- `make verify` — passing, including licensing, metadata, branch-scope, Implementation Pack, and planning suites
- `bash ./utl/gh/repo-metadata.sh --check` — local and remote contracts passing
- `git diff --check` — passing

Closes #91
