### PR TITLE
fix: support Project pull-request field values

### DIFF
--- a/utl/gh/RUNBOOK.md
+++ b/utl/gh/RUNBOOK.md
@@ -269,7 +269,8 @@ never accepted on argv, read from a file, or emitted.
 1. Run live verification before and after every governed planning transition
    and preserve the canonical JSON result digest/result as transition evidence.
 2. Exhaust every observed Project-item, Project-field, item-field-value,
-   User-member, and Label-member connection at both observation endpoints.
+   User-member, Label-member, and PullRequest-member connection at both
+   observation endpoints.
    Identity, accessibility, supported value variants, uniqueness, closure
    limits, and start/end stability fail closed with redacted diagnostics.
 3. Never treat a Plan digest or approval-reference string as proof of PO

--- a/utl/gh/planning-github-observer.mjs
+++ b/utl/gh/planning-github-observer.mjs
@@ -14,6 +14,10 @@ const FIELD_VALUE_SELECTION = `
     field { ... on ProjectV2FieldCommon { id } }
     labels(first: $pageSize) { nodes { id } pageInfo { hasNextPage endCursor } }
   }
+  ... on ProjectV2ItemFieldPullRequestValue {
+    field { ... on ProjectV2FieldCommon { id } }
+    pullRequests(first: $pageSize) { nodes { id } pageInfo { hasNextPage endCursor } }
+  }
   ... on ProjectV2ItemFieldTextValue {
     id
     field { ... on ProjectV2FieldCommon { id } }
@@ -52,6 +56,9 @@ export const QUERY_DOCUMENTS = Object.freeze({
   labelMembers: `query PlanningObservationLabelMembers($itemId: ID!, $valueAfter: String, $memberCursor: String!, $pageSize: Int!) {
     item: node(id: $itemId) { ... on ProjectV2Item { fieldValues(first: 1, after: $valueAfter) { edges { cursor node { __typename ... on ProjectV2ItemFieldLabelValue { field { ... on ProjectV2FieldCommon { id } } labels(first: $pageSize, after: $memberCursor) { nodes { id } pageInfo { hasNextPage endCursor } } } } } } } }
   }`,
+  pullRequestMembers: `query PlanningObservationPullRequestMembers($itemId: ID!, $valueAfter: String, $memberCursor: String!, $pageSize: Int!) {
+    item: node(id: $itemId) { ... on ProjectV2Item { fieldValues(first: 1, after: $valueAfter) { edges { cursor node { __typename ... on ProjectV2ItemFieldPullRequestValue { field { ... on ProjectV2FieldCommon { id } } pullRequests(first: $pageSize, after: $memberCursor) { nodes { id } pageInfo { hasNextPage endCursor } } } } } } } }
+  }`,
   end: `query PlanningObservationEnd($repositoryId: ID!, $issueId: ID!, $projectId: ID!, $itemId: ID!, $statusFieldId: ID!, $pageSize: Int!) {
     repository: node(id: $repositoryId) { __typename id }
     issue: node(id: $issueId) { id ... on Issue { number state body updatedAt } }
@@ -64,7 +71,7 @@ export const QUERY_DOCUMENTS = Object.freeze({
   }`,
 });
 
-const DEFAULT_LIMITS = Object.freeze({ pageSize: 100, pages: 100, items: 10_000, fields: 1_000, values: 1_000, users: 1_000, labels: 1_000, bodyBytes: 1_000_000 });
+const DEFAULT_LIMITS = Object.freeze({ pageSize: 100, pages: 100, items: 10_000, fields: 1_000, values: 1_000, users: 1_000, labels: 1_000, pullRequests: 1_000, bodyBytes: 1_000_000 });
 
 function isRecord(value) {
   return value !== null && typeof value === "object" && !Array.isArray(value);
@@ -195,6 +202,10 @@ async function normalizeFieldValues(transport, entries, itemId, limits, prefix) 
       const labels = await exhaustNestedMembers({ transport, entry, limits, prefix, typename: value.__typename, connectionName: "labels", query: QUERY_DOCUMENTS.labelMembers, limitName: "labels" });
       if (!labels.ok) return labels;
       values.push({ valueType: value.__typename, fieldId, labelIds: labels.value });
+    } else if (value.__typename === "ProjectV2ItemFieldPullRequestValue") {
+      const pullRequests = await exhaustNestedMembers({ transport, entry, limits, prefix, typename: value.__typename, connectionName: "pullRequests", query: QUERY_DOCUMENTS.pullRequestMembers, limitName: "pullRequests" });
+      if (!pullRequests.ok) return pullRequests;
+      values.push({ valueType: value.__typename, fieldId, pullRequestIds: pullRequests.value });
     } else if (value.__typename === "ProjectV2ItemFieldTextValue") {
       if (typeof value.id !== "string" || value.id.length === 0 || !Object.hasOwn(value, "text") || (value.text !== null && typeof value.text !== "string")) return inaccessible();
       values.push({ valueType: value.__typename, fieldId, valueIdentity: value.id, text: value.text });

--- a/utl/gh/planning-github-observer.test.mjs
+++ b/utl/gh/planning-github-observer.test.mjs
@@ -84,6 +84,10 @@ function optionalValue(kind, memberIds = ["M_1", "M_2"]) {
       field: { id: "PVTF_labels", name: "Labels" },
       value: { __typename: "ProjectV2ItemFieldLabelValue", field: { id: "PVTF_labels" }, labels: page(memberIds.map((id) => ({ id: `L_${id}` }))) },
     },
+    PullRequest: {
+      field: { id: "PVTF_pull_requests", name: "Linked pull requests" },
+      value: { __typename: "ProjectV2ItemFieldPullRequestValue", field: { id: "PVTF_pull_requests" }, pullRequests: page(memberIds.map((id) => ({ id: `PR_${id}` }))) },
+    },
     Text: {
       field: { id: "PVTF_text", name: "Text" },
       value: { __typename: "ProjectV2ItemFieldTextValue", id: "PVTFV_text", field: { id: "PVTF_text" }, text: null },
@@ -104,6 +108,7 @@ function addMixedSupportedValues(snapshot, reverse = false) {
     { id: "PVTF_users", name: "Users" },
     { id: "PVTF_repository", name: "Repository" },
     { id: "PVTF_labels", name: "Labels" },
+    { id: "PVTF_pull_requests", name: "Linked pull requests" },
     { id: "PVTF_text", name: "Text" },
   ];
   const memberIds = reverse ? ["M_2", "M_1"] : ["M_1", "M_2"];
@@ -111,6 +116,7 @@ function addMixedSupportedValues(snapshot, reverse = false) {
     { __typename: "ProjectV2ItemFieldUserValue", field: { id: "PVTF_users" }, users: page(memberIds.map((id) => ({ id }))) },
     { __typename: "ProjectV2ItemFieldRepositoryValue", field: { id: "PVTF_repository" }, repository: { id: "R_value" } },
     { __typename: "ProjectV2ItemFieldLabelValue", field: { id: "PVTF_labels" }, labels: page(memberIds.map((id) => ({ id: `L_${id}` }))) },
+    { __typename: "ProjectV2ItemFieldPullRequestValue", field: { id: "PVTF_pull_requests" }, pullRequests: page(memberIds.map((id) => ({ id: `PR_${id}` }))) },
     { __typename: "ProjectV2ItemFieldTextValue", id: "PVTFV_text", field: { id: "PVTF_text" }, text: null },
   ];
   snapshot.project.fields.nodes.push(...(reverse ? fields.reverse() : fields));
@@ -179,7 +185,7 @@ function transportFixture(overrides = {}) {
     if (query === QUERY_DOCUMENTS.items) return { data: { project: { items: overrides.itemPages?.[variables.cursor] ?? overrides.itemsPage ?? page([]) } } };
     if (query === QUERY_DOCUMENTS.fields) return { data: { project: { fields: overrides.fieldPages?.[variables.cursor] ?? overrides.fieldsPage ?? page([]) } } };
     if (query === QUERY_DOCUMENTS.values) return { data: { item: { fieldValues: overrides.valuePages?.[variables.cursor] ?? overrides.valuesPage ?? page([]) } } };
-    if (query === QUERY_DOCUMENTS.userMembers || query === QUERY_DOCUMENTS.labelMembers) {
+    if (query === QUERY_DOCUMENTS.userMembers || query === QUERY_DOCUMENTS.labelMembers || query === QUERY_DOCUMENTS.pullRequestMembers) {
       const memberPage = overrides.memberPages?.[variables.memberCursor];
       if (memberPage !== undefined) return { data: memberPage };
     }
@@ -254,7 +260,7 @@ test("complete stable observation binds every identity and validates without net
 });
 
 test("each supported field-value variant uses only its minimal provider projection", async () => {
-  for (const kind of ["SingleSelect", "User", "Repository", "Label", "Text"]) {
+  for (const kind of ["SingleSelect", "User", "Repository", "Label", "PullRequest", "Text"]) {
     const fixture = transportFixture();
     if (kind !== "SingleSelect") {
       addOptionalValue(fixture.start, kind);
@@ -285,7 +291,7 @@ test("synthetic #128-shaped mixed closure remains Backlog evidence without workf
   assert.doesNotMatch(JSON.stringify(verdict), /"(?:command|transition|mutation|calls?)"/iu);
 });
 
-test("canonical sorting independently tolerates top-level, User-member, and Label-member reordering", async () => {
+test("canonical sorting independently tolerates top-level and nested-member reordering", async () => {
   const cases = [
     ["top-level", (end) => {
       end.project.items.nodes.reverse();
@@ -294,6 +300,7 @@ test("canonical sorting independently tolerates top-level, User-member, and Labe
     }],
     ["User members", (end) => { end.item.fieldValues.nodes.find(({ __typename }) => __typename === "ProjectV2ItemFieldUserValue").users.nodes.reverse(); }],
     ["Label members", (end) => { end.item.fieldValues.nodes.find(({ __typename }) => __typename === "ProjectV2ItemFieldLabelValue").labels.nodes.reverse(); }],
+    ["PullRequest members", (end) => { end.item.fieldValues.nodes.find(({ __typename }) => __typename === "ProjectV2ItemFieldPullRequestValue").pullRequests.nodes.reverse(); }],
   ];
   for (const [name, reorder] of cases) {
     const fixture = transportFixture();
@@ -330,18 +337,20 @@ test("start and end independently enumerate stable multipage closures", async ()
   assert.deepEqual(new Set(wrapped.calls.filter(({ variables }) => variables.cursor).map(({ variables }) => variables.cursor)), new Set(["items-1", "fields-1", "values-1", "end-items-1", "end-fields-1", "end-values-1"]));
 });
 
-test("outer values and nested User and Label members paginate independently at both window endpoints", async () => {
+test("outer values and nested User, Label, and PullRequest members paginate independently at both window endpoints", async () => {
   const fixture = transportFixture();
   function configure(snapshot, prefix) {
-    const definitions = [optionalValue("User"), optionalValue("Repository"), optionalValue("Label"), optionalValue("Text")];
+    const definitions = [optionalValue("User"), optionalValue("Repository"), optionalValue("Label"), optionalValue("PullRequest"), optionalValue("Text")];
     snapshot.project.fields.nodes.push(...definitions.map(({ field }) => field));
     const user = definitions[0].value;
     const label = definitions[2].value;
+    const pullRequest = definitions[3].value;
     user.users = page([{ id: "M_1" }], true, `${prefix}-users-1`);
     label.labels = page([{ id: "L_M_1" }], true, `${prefix}-labels-1`);
+    pullRequest.pullRequests = page([{ id: "PR_M_1" }], true, `${prefix}-pull-requests-1`);
     snapshot.item.fieldValues = page([statusValue()], true, `${prefix}-values-1`);
     const continuation = page(definitions.map(({ value }) => value));
-    return { continuation, user, label };
+    return { continuation, user, label, pullRequest };
   }
   const start = configure(fixture.start, "start");
   const end = configure(fixture.end, "end");
@@ -353,11 +362,15 @@ test("outer values and nested User and Label members paginate independently at b
   const startLabelCursor = start.continuation.edges.find(({ node }) => node === start.label).cursor;
   const endUserCursor = end.continuation.edges.find(({ node }) => node === end.user).cursor;
   const endLabelCursor = end.continuation.edges.find(({ node }) => node === end.label).cursor;
+  const startPullRequestCursor = start.continuation.edges.find(({ node }) => node === start.pullRequest).cursor;
+  const endPullRequestCursor = end.continuation.edges.find(({ node }) => node === end.pullRequest).cursor;
   const memberPages = {
     "start-users-1": nestedMemberData(start.user, startUserCursor, "users", page([{ id: "M_2" }])),
     "end-users-1": nestedMemberData(end.user, endUserCursor, "users", page([{ id: "M_2" }])),
     "start-labels-1": nestedMemberData(start.label, startLabelCursor, "labels", page([{ id: "L_M_2" }])),
     "end-labels-1": nestedMemberData(end.label, endLabelCursor, "labels", page([{ id: "L_M_2" }])),
+    "start-pull-requests-1": nestedMemberData(start.pullRequest, startPullRequestCursor, "pullRequests", page([{ id: "PR_M_2" }])),
+    "end-pull-requests-1": nestedMemberData(end.pullRequest, endPullRequestCursor, "pullRequests", page([{ id: "PR_M_2" }])),
   };
   const wrapped = transportFixture({ start: fixture.start, end: fixture.end, valuePages, memberPages });
   const result = await observePlanning(expectedEnvelope(), { transport: wrapped.transport });
@@ -368,7 +381,7 @@ test("outer values and nested User and Label members paginate independently at b
   );
   assert.deepEqual(
     wrapped.calls.filter(({ variables }) => variables.memberCursor).map(({ variables }) => variables.memberCursor).sort(),
-    ["end-labels-1", "end-users-1", "start-labels-1", "start-users-1"],
+    ["end-labels-1", "end-pull-requests-1", "end-users-1", "start-labels-1", "start-pull-requests-1", "start-users-1"],
   );
 });
 
@@ -402,6 +415,7 @@ test("malformed required members and unsupported variants fail closed with one r
     ["User connection", { __typename: "ProjectV2ItemFieldUserValue", field: { id: "PVTF_bad" } }],
     ["Repository identity", { __typename: "ProjectV2ItemFieldRepositoryValue", field: { id: "PVTF_bad" }, repository: { id: "" } }],
     ["Label connection", { __typename: "ProjectV2ItemFieldLabelValue", field: { id: "PVTF_bad" }, labels: null }],
+    ["PullRequest connection", { __typename: "ProjectV2ItemFieldPullRequestValue", field: { id: "PVTF_bad" }, pullRequests: null }],
     ["Text value identity", { __typename: "ProjectV2ItemFieldTextValue", field: { id: "PVTF_bad" }, text: null }],
     ["Text presence", { __typename: "ProjectV2ItemFieldTextValue", id: "PVTFV_bad", field: { id: "PVTF_bad" } }],
     ["Text type", { __typename: "ProjectV2ItemFieldTextValue", id: "PVTFV_bad", field: { id: "PVTF_bad" }, text: { secret: "SECRET_TEXT_TYPE" } }],
@@ -442,10 +456,10 @@ test("outer field-value pagination fails on missing cursor, locator truncation, 
   expectCode(await observePlanning(expectedEnvelope(), { transport: capped.transport, limits: { values: 1 } }), "OBSERVATION_LIMIT");
 });
 
-test("nested User and Label pagination fails on incomplete closure, member limits, duplicates, and locator drift", async () => {
-  for (const kind of ["User", "Label"]) {
-    const connectionName = kind === "User" ? "users" : "labels";
-    const limitName = kind === "User" ? "users" : "labels";
+test("nested member pagination fails on incomplete closure, member limits, duplicates, and locator drift", async () => {
+  for (const kind of ["User", "Label", "PullRequest"]) {
+    const connectionName = kind === "User" ? "users" : kind === "Label" ? "labels" : "pullRequests";
+    const limitName = connectionName;
 
     const missingCursor = transportFixture();
     const missingValue = addOptionalValue(missingCursor.start, kind);
@@ -596,6 +610,7 @@ test("semantic movement in every supported field-value variant is observation dr
     ["User", (value) => { value.users.nodes.push({ id: "M_3" }); }],
     ["Repository", (value) => { value.repository.id = "R_moved"; }],
     ["Label", (value) => { value.labels.nodes.push({ id: "L_M_3" }); }],
+    ["PullRequest", (value) => { value.pullRequests.nodes.push({ id: "PR_M_3" }); }],
     ["Text", (value) => { value.text = "moved"; }],
   ];
   for (const [kind, mutate] of cases) {


### PR DESCRIPTION
## Summary

- support exactly `ProjectV2ItemFieldPullRequestValue` in the live read-only planning observer;
- exhaust and identity-revalidate nested pull-request pagination at both observation endpoints;
- preserve canonical ordering, existing redacted fail-closed diagnostics, exact Status validation, and evidence-only authority.

## Root cause

GitHub adds a PullRequest field value when an Issue has a linked PR. #142 intentionally supported only five named variants, so the closed observer rejected this separately scoped provider variant before planning-policy validation.

## Verification

- Red-first observer suite: expected `19/26` pass before production edits.
- Green observer suite: `26/26` pass.
- `make verify`: pass.
- `make test`: pass; CLI/package `132/132`, Capability `31/31`.
- `git diff --check`: pass.
- Live #122 replay: `plan-status-only`, `In progress`, `authorityEffect: none`.

Closes #148

## Implementation Pack
### Authority bindings
- Work item: `#148`
- Requirements: `sha256:b2ddbab77adf1d0726d421afaf4862a7631233ef2967d61a91e94390f27acae1`
- Ready authority: `codex-session:2026-08-19:po:#148-minimal-rc-01-hotfix`
- Base Authorization: `BA148-01:5339580899`
- Publication Intent: `PI148-01:5339641589`
- Architecture: `n/a`
- AI Strategy: `n/a; not-ai-impacting`
- Capability Assessment: `n/a`
- Review A: `n/a`
- Review B: `pending`

### Changed boundaries
- `utl/gh/planning-github-observer.mjs`: minimal PullRequest selection, pagination query, bounded normalization, and canonical ID projection.
- `utl/gh/planning-github-observer.test.mjs`: positive, ordering, pagination, cap, duplicate, locator, malformed, drift, and redaction coverage.
- `utl/gh/RUNBOOK.md`: truthful complete nested-connection statement.

### Decisions and failure behavior
- Reuse the #142 edge-locator and generic nested-member machinery; do not create synthetic identities or a second observer path.
- Support no additional union variant; unknown variants remain `PROVIDER_INACCESSIBLE`.
- Incomplete/capped pagination, duplicate IDs, locator drift, malformed payloads, or semantic movement retain existing registered redacted failures.
- The observer remains query-only and grants no workflow or mutation authority.

### Acceptance evidence
- AC-01: `FIELD_VALUE_SELECTION`, `normalizeFieldValues`; per-variant and mixed-closure tests.
- AC-02: `pullRequestMembers`, `exhaustNestedMembers`; start/end pagination, cap, duplicate, and locator tests.
- AC-03: `memberIds`, `closureSummary`; PullRequest reorder stability test.
- AC-04: malformed, incomplete, duplicate, cap, locator, and semantic-drift tests.
- AC-05: complete planning suite `73/73`; query-only export test.
- AC-06: Test Evidence Pack `sha256:8c8ae19ff38470bd276da3da12f681ef567855d4869e6ae9d254f9e25357d620`.
- AC-07: live #122 proof `sha256:b0c065bc95eb2bec2ab74120ab06bc91ac289a7bfe9b68567b25e542905d90c1`.

### Verification and candidate
- Candidate identity: `git:467afa3b369c4967efa92437b6ec7b55b2bb45ee`
- Candidate tree: `3866b10b994cc08aff8565725e2abfacdb72d8af`
- Verification: `node --test utl/gh/planning-github-observer.test.mjs` — pass `26/26`.
- Verification: `make verify` — pass.
- Verification: `make test` — pass.
- Verification: `git diff --check` — pass.
- Verification: branch-scope local/pre-push — pass.

### Residual risks and follow-ups
- Future unknown Project field-value variants intentionally block until separately scoped.
- Independent Review B, PR reconciliation, Final Conformance, and PO merge authority remain pending.
- Local Codex CLI is `0.148.0` while the governed session-hygiene measurement adapter supports `0.147.0`; a fresh CLI review/restart is therefore not claimed as governed evidence.

**DO NOT MERGE.**
