### PR TITLE
fix: support Codex 0.148.0 in session hygiene

### DIFF
--- a/util/repository/session-hygiene/codex-version-contract.mjs
+++ b/util/repository/session-hygiene/codex-version-contract.mjs
@@ -1,0 +1,7 @@
+export const ACCEPTED_CODEX_VERSIONS = Object.freeze(["0.147.0", "0.148.0"]);
+
+const acceptedVersions = new Set(ACCEPTED_CODEX_VERSIONS);
+
+export function acceptsCodexVersion(version) {
+  return acceptedVersions.has(version);
+}

--- a/util/repository/session-hygiene/codex-version-contract.test.mjs
+++ b/util/repository/session-hygiene/codex-version-contract.test.mjs
@@ -1,0 +1,14 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { ACCEPTED_CODEX_VERSIONS, acceptsCodexVersion } from "./codex-version-contract.mjs";
+
+test("owns the exact closed Codex version set", () => {
+  assert.deepEqual(ACCEPTED_CODEX_VERSIONS, ["0.147.0", "0.148.0"]);
+  assert.equal(Object.isFrozen(ACCEPTED_CODEX_VERSIONS), true);
+
+  for (const version of ACCEPTED_CODEX_VERSIONS) assert.equal(acceptsCodexVersion(version), true);
+  for (const version of ["0.146.0", "0.147.1", "0.148.1", "0.149.0", "0.148", "v0.148.0", null]) {
+    assert.equal(acceptsCodexVersion(version), false);
+  }
+});

--- a/util/repository/session-hygiene/evaluate.mjs
+++ b/util/repository/session-hygiene/evaluate.mjs
@@ -1,4 +1,5 @@
 import { loadPolicyProjection, validatePolicyProjection } from "./projection.mjs";
+import { acceptsCodexVersion } from "./codex-version-contract.mjs";
 
 const EVALUATION_SCHEMA = "ai4x.session-hygiene-evaluation/v1";
 const OBSERVATION_SCHEMA = "ai4x.codex-session-observation/v1";
@@ -207,7 +208,7 @@ function validateObservation(policy, input, add) {
   }
   if (!isRecord(observation.binding)
     || observation.binding.provider !== "codex"
-    || observation.binding.providerVersion !== "0.147.0"
+    || !acceptsCodexVersion(observation.binding.providerVersion)
     || observation.binding.sessionIdPresent !== true
     || observation.binding.parentPathValidated !== true
     || observation.binding.cwdMatchesProject !== true) {

--- a/util/repository/session-hygiene/evaluate.test.mjs
+++ b/util/repository/session-hygiene/evaluate.test.mjs
@@ -133,6 +133,23 @@ test("allows a fresh, bound observation and one write-capable delegated Assignme
   assert.deepEqual(result.diagnostics, []);
 });
 
+test("accepts exactly the closed Codex version set through evaluation", () => {
+  const binding = (providerVersion) => ({
+    provider: "codex",
+    providerVersion,
+    sessionIdPresent: true,
+    parentPathValidated: true,
+    cwdMatchesProject: true,
+  });
+  for (const providerVersion of ["0.147.0", "0.148.0"]) {
+    assert.equal(evaluate(policy(), input({ observation: { binding: binding(providerVersion) } })).decision, "allow");
+  }
+  for (const providerVersion of ["0.146.0", "0.147.1", "0.149.0"]) {
+    const result = evaluate(policy(), input({ observation: { binding: binding(providerVersion) } }));
+    assert.ok(codes(result).includes("SH-OBSERVATION-BINDING-INVALID"));
+  }
+});
+
 test("ordinary evaluation rejects incomplete, manipulated, and stale projection provenance", () => {
   const incomplete = policy();
   incomplete.provenance.sources = [];

--- a/util/repository/session-hygiene/measure-codex.mjs
+++ b/util/repository/session-hygiene/measure-codex.mjs
@@ -14,9 +14,10 @@ import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
+import { acceptsCodexVersion } from "./codex-version-contract.mjs";
+
 const REQUEST_SCHEMA = "ai4x.codex-session-measurement-request/v1";
 const RESULT_SCHEMA = "ai4x.codex-session-observation/v1";
-const SUPPORTED_VERSION = "0.147.0";
 const LIFECYCLES = new Set(["before-delegation", "active-interval", "subagent-stop", "after-issue-completion", "handoff-boundary"]);
 
 export class MeasurementFailure extends Error {
@@ -108,7 +109,7 @@ export function measureCodexRequest(request, overrides = {}) {
     fail("SH-MEASURE-INVALID-REQUEST", "measurement request schema is invalid");
   }
   if (request.provider !== "codex") fail("SH-MEASURE-UNSUPPORTED-PROVIDER", "provider is unsupported");
-  if (request.providerVersion !== SUPPORTED_VERSION) fail("SH-MEASURE-UNSUPPORTED-VERSION", "provider version is unsupported");
+  if (!acceptsCodexVersion(request.providerVersion)) fail("SH-MEASURE-UNSUPPORTED-VERSION", "provider version is unsupported");
   if (!LIFECYCLES.has(request.lifecycle)) fail("SH-MEASURE-INVALID-LIFECYCLE", "lifecycle is unsupported");
   for (const field of ["issue", "sessionId", "transcriptPath", "cwd", "projectRoot", "codexHome"]) {
     if (!nonEmpty(request[field])) fail("SH-MEASURE-MISSING-FIELD", `required field is absent: ${field}`);
@@ -153,7 +154,7 @@ export function measureCodexRequest(request, overrides = {}) {
     childRollout: Object.freeze(childRollout),
     binding: Object.freeze({
       provider: "codex",
-      providerVersion: SUPPORTED_VERSION,
+      providerVersion: request.providerVersion,
       sessionIdPresent: true,
       parentPathValidated: true,
       cwdMatchesProject: true,
@@ -178,4 +179,3 @@ if (process.argv[1] === fileURLToPath(import.meta.url)) process.exitCode = main(
 
 export const CODEX_MEASUREMENT_REQUEST_SCHEMA = REQUEST_SCHEMA;
 export const CODEX_MEASUREMENT_RESULT_SCHEMA = RESULT_SCHEMA;
-export const SUPPORTED_CODEX_VERSION = SUPPORTED_VERSION;

--- a/util/repository/session-hygiene/measure-codex.test.mjs
+++ b/util/repository/session-hygiene/measure-codex.test.mjs
@@ -56,17 +56,20 @@ function failureCode(action) {
   return null;
 }
 
-test("measures exact parent metadata and disk without returning a path or transcript content", () => {
+test("measures both accepted versions exactly without returning a path or transcript content", () => {
   const fx = fixture();
   try {
     const before = readFileSync(fx.parentPath);
-    const result = measure(fx, request(fx));
-    assert.equal(result.parentRolloutBytes, before.length);
-    assert.equal(result.childRollout.state, "not-created");
-    assert.equal(result.binding.parentPathValidated, true);
-    assert.equal(result.observedAtEpochSeconds, 1_000);
-    assert.ok(result.freeBytes > 0);
-    assert.doesNotMatch(JSON.stringify(result), /parent secret|sessions|rollout-|\.jsonl/);
+    for (const providerVersion of ["0.147.0", "0.148.0"]) {
+      const result = measure(fx, request(fx, { providerVersion }));
+      assert.equal(result.parentRolloutBytes, before.length);
+      assert.equal(result.childRollout.state, "not-created");
+      assert.equal(result.binding.providerVersion, providerVersion);
+      assert.equal(result.binding.parentPathValidated, true);
+      assert.equal(result.observedAtEpochSeconds, 1_000);
+      assert.ok(result.freeBytes > 0);
+      assert.doesNotMatch(JSON.stringify(result), /parent secret|sessions|rollout-|\.jsonl/);
+    }
     assert.deepEqual(readFileSync(fx.parentPath), before);
   } finally {
     rmSync(fx.root, { recursive: true, force: true });
@@ -90,10 +93,23 @@ test("reports pending child path during activity and measures only provider path
   }
 });
 
-test("fails closed for unsupported provider version and project mismatch", () => {
+test("fails closed below, between, and above the exact accepted version set", () => {
   const fx = fixture();
   try {
-    assert.equal(failureCode(() => measure(fx, request(fx, { providerVersion: "0.148.0" }))), "SH-MEASURE-UNSUPPORTED-VERSION");
+    for (const providerVersion of ["0.146.0", "0.147.1", "0.149.0"]) {
+      assert.equal(
+        failureCode(() => measure(fx, request(fx, { providerVersion }))),
+        "SH-MEASURE-UNSUPPORTED-VERSION",
+      );
+    }
+  } finally {
+    rmSync(fx.root, { recursive: true, force: true });
+  }
+});
+
+test("fails closed for project mismatch", () => {
+  const fx = fixture();
+  try {
     assert.equal(failureCode(() => measure(fx, request(fx, { cwd: fx.root }))), "SH-MEASURE-PROJECT-BINDING");
     assert.equal(failureCode(() => measure(fx, request(fx, { cwd: fx.root, projectRoot: fx.root }))), "SH-MEASURE-PROJECT-BINDING");
     assert.equal(failureCode(() => measure(fx, request(fx, { codexHome: fx.root }))), "SH-MEASURE-PATH-ESCAPE");


### PR DESCRIPTION
## Summary

- centralize the exact accepted Codex versions in one closed contract;
- accept only `0.147.0` and `0.148.0` in measurement and evaluation;
- preserve the exact accepted request version in observation evidence while retaining all read-only path and identity safeguards.

## Verification

- Red-first focused suite: expected `25/27` pass before production edits.
- Session-hygiene suite: `38/38` pass.
- `make verify`: pass.
- `make test`: pass; CLI/package `132/132`, Capability `31/31`.
- `git diff --check`: pass.
- No real-session measurement is claimed: the currently installed CLI is `0.149.0`, which remains intentionally rejected.

Closes #150

## Implementation Pack
### Authority bindings
- Work item: `#150`
- Requirements: `sha256:10377cef9f2ce3fa39a2d6065d648457ffd14ce737ecba5cff9db89cbcc46078`
- Ready authority: `codex-session:2026-08-19:po:#150-adapter-0148`
- Base Authorization: `BA150-01:5365837076`
- Publication Intent: `PI150-01:5365900943`
- Architecture: `n/a`
- AI Strategy: `n/a; not-ai-impacting`
- Capability Assessment: `n/a`
- Review A: `n/a`
- Review B: `pending; current parent CLI 0.149.0 blocks governed delegation`

### Changed boundaries
- `codex-version-contract.mjs` and its test own the immutable exact two-version set and membership boundary.
- `measure-codex.mjs` consumes the shared contract and preserves the accepted request version in the binding; its tests cover both versions and closed-set adversaries.
- `evaluate.mjs` consumes the same contract; its tests prove both accepted bindings and rejection below, between, and above them.

### Decisions and failure behavior
- Use exact string membership, not semantic-version ranges, ordering, discovery, or future-version inference.
- Preserve the existing `SH-MEASURE-UNSUPPORTED-VERSION` and `SH-OBSERVATION-BINDING-INVALID` fail-closed diagnostics.
- Keep every existing exact-path, containment, identity, TOCTOU, project/Codex-root, redaction, lifecycle, threshold, and non-mutation invariant unchanged.
- Cleanup, deletion, archive, process control, transcript parsing, filesystem scanning, and Codex `0.149.0` support remain out of scope.

### Acceptance evidence
- AC-01: measurement tests prove unchanged `0.147.0` success.
- AC-02: measurement and evaluation tests prove `0.148.0` success with exact `binding.providerVersion` preservation.
- AC-03: contract/consumer tests reject `0.146.0`, `0.147.1`, `0.148.1`, `0.149.0`, and malformed variants.
- AC-04: both production consumers import `acceptsCodexVersion` from the sole shared contract.
- AC-05: complete session-hygiene suite `38/38` retains the read-only and safety boundary.
- AC-06: Test Evidence Pack `sha256:ab0581a3f3df793585af3e38a4ca8ae46fcf3eaf3458b271dda643d7cd9a43b3`.
- AC-07: Independent Review B remains pending and no post-merge restart claim is made.

### Verification and candidate
- Candidate identity: `git:576e39f63894f3a3119791caaaa373d895b9aec4`
- Candidate tree: `693a436e3edf6d81ce95f61509ae75de291be14a`
- Verification: `make session-hygiene-test` — pass `38/38`.
- Verification: `make verify` — pass.
- Verification: `make test` — pass.
- Verification: `git diff --check` — pass.
- Verification: branch-scope local/pre-push — pass.

### Residual risks and follow-ups
- Installed `codex-cli 0.149.0` remains intentionally unsupported; no governed measurement or session path claim is made.
- Independent Review B, PR reconciliation, CI, Final Conformance, and PO merge authority remain pending.
- The separately proposed Codex-session cleanup portfolio capability remains out of #150 scope and requires its own approved contract.

**DO NOT MERGE.**
