### PR TITLE
Make the Golden greenfield rule explicit

### DIFF
--- a/.ai4x/BEHAVIOR.md
+++ b/.ai4x/BEHAVIOR.md
@@ -14,6 +14,8 @@ Product Owner decision outranks defaults and local convention.
 - Keep one authority for each fact. Generated and local state are never authorities.
 - Use live repository and GitHub state for mutable facts; historical evidence is not current state.
 - Keep local, backup, generated, prototype, and research material out of `trunk` until an active product slice deliberately adopts it.
+- Design adopted slices from current needs and explicit invariants. Never restore legacy structures or use workarounds, speculative hooks, or patchwork as product design.
+- Prefer coherent module ownership, deterministic behavior, traceable decisions, and measured performance.
 
 ## Working style
 


### PR DESCRIPTION
## Summary

- make the approved greenfield rule durable in canonical ai4X behavior
- prohibit legacy restoration, workaround design, speculative hooks, and patchwork
- require coherent ownership, determinism, traceability, and measured performance

This is a refinement safeguard for #102 and all later product slices. It changes no product implementation.

## Verification

- `make verify`
- `git diff --check`
