### PR TITLE
Expose proportionate verification as visible CI jobs

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -45,6 +45,36 @@ jobs:
             esac
           }
 
+          validate_documentation_policy() {
+            local path
+
+            for path in \
+              README.md \
+              .ai4x/context/architecture.md \
+              .github/copilot-instructions.md \
+              doc/reference/example.md; do
+              if ! is_documentation_path "$path"; then
+                printf '::error::approved documentation path was rejected: %s\n' "$path"
+                return 1
+              fi
+            done
+
+            for path in \
+              Makefile \
+              .github/workflows/verify.yml \
+              .github/agents/reviewer.md \
+              doc/examples/example.sh \
+              src/foundation/core/src/AI4X/Core.hs \
+              future/README.md; do
+              if is_documentation_path "$path"; then
+                printf '::error::technical or unknown path was accepted as documentation: %s\n' "$path"
+                return 1
+              fi
+            done
+          }
+
+          validate_documentation_policy
+
           haskell_required=true
           haskell_reason='Haskell runs: changed paths were not proven documentation-only.'
           base_sha=''
@@ -173,6 +203,38 @@ jobs:
           HASKELL_REQUIRED: ${{ needs.structure.outputs.haskell_required }}
         run: |
           set -u
+
+          aggregate_is_valid() {
+            local structure_result="$1"
+            local licensing_result="$2"
+            local haskell_result="$3"
+            local haskell_required="$4"
+
+            [[ "$structure_result" == 'success' && "$licensing_result" == 'success' ]] || return 1
+
+            if [[ "$haskell_required" == 'true' ]]; then
+              [[ "$haskell_result" == 'success' ]]
+            elif [[ "$haskell_required" == 'false' ]]; then
+              [[ "$haskell_result" == 'skipped' ]]
+            else
+              return 1
+            fi
+          }
+
+          if ! aggregate_is_valid success success success true || \
+              ! aggregate_is_valid success success skipped false; then
+            printf '::error::valid aggregate policy fixture was rejected\n'
+            exit 1
+          fi
+
+          if aggregate_is_valid failure success skipped false || \
+              aggregate_is_valid success failure skipped false || \
+              aggregate_is_valid success success skipped true || \
+              aggregate_is_valid success success success false || \
+              aggregate_is_valid success success skipped ''; then
+            printf '::error::invalid aggregate policy fixture was accepted\n'
+            exit 1
+          fi
 
           verification_failed=false
 

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -73,7 +73,9 @@ jobs:
             done
           }
 
-          validate_documentation_policy
+          if ! validate_documentation_policy; then
+            exit 1
+          fi
 
           haskell_required=true
           haskell_reason='Haskell runs: changed paths were not proven documentation-only.'
@@ -236,33 +238,6 @@ jobs:
             exit 1
           fi
 
-          verification_failed=false
-
-          if [[ "$STRUCTURE_RESULT" != 'success' ]]; then
-            printf '::error::structure concluded %s\n' "$STRUCTURE_RESULT"
-            verification_failed=true
-          fi
-
-          if [[ "$LICENSING_RESULT" != 'success' ]]; then
-            printf '::error::licensing concluded %s\n' "$LICENSING_RESULT"
-            verification_failed=true
-          fi
-
-          if [[ "$HASKELL_REQUIRED" == 'true' ]]; then
-            if [[ "$HASKELL_RESULT" != 'success' ]]; then
-              printf '::error::haskell was required but concluded %s\n' "$HASKELL_RESULT"
-              verification_failed=true
-            fi
-          elif [[ "$HASKELL_REQUIRED" == 'false' ]]; then
-            if [[ "$HASKELL_RESULT" != 'skipped' ]]; then
-              printf '::error::haskell was not required but concluded %s\n' "$HASKELL_RESULT"
-              verification_failed=true
-            fi
-          else
-            printf '::error::haskell requirement was missing or invalid: %s\n' "$HASKELL_REQUIRED"
-            verification_failed=true
-          fi
-
           {
             printf '### Verification aggregate\n\n'
             printf -- '- `structure`: `%s`\n' "$STRUCTURE_RESULT"
@@ -270,6 +245,26 @@ jobs:
             printf -- '- `haskell`: `%s` (required: `%s`)\n' "$HASKELL_RESULT" "$HASKELL_REQUIRED"
           } >> "$GITHUB_STEP_SUMMARY"
 
-          if [[ "$verification_failed" == true ]]; then
+          if ! aggregate_is_valid \
+              "$STRUCTURE_RESULT" \
+              "$LICENSING_RESULT" \
+              "$HASKELL_RESULT" \
+              "$HASKELL_REQUIRED"; then
+            if [[ "$STRUCTURE_RESULT" != 'success' ]]; then
+              printf '::error::structure concluded %s\n' "$STRUCTURE_RESULT"
+            fi
+
+            if [[ "$LICENSING_RESULT" != 'success' ]]; then
+              printf '::error::licensing concluded %s\n' "$LICENSING_RESULT"
+            fi
+
+            if [[ "$HASKELL_REQUIRED" == 'true' && "$HASKELL_RESULT" != 'success' ]]; then
+              printf '::error::haskell was required but concluded %s\n' "$HASKELL_RESULT"
+            elif [[ "$HASKELL_REQUIRED" == 'false' && "$HASKELL_RESULT" != 'skipped' ]]; then
+              printf '::error::haskell was not required but concluded %s\n' "$HASKELL_RESULT"
+            elif [[ "$HASKELL_REQUIRED" != 'true' && "$HASKELL_REQUIRED" != 'false' ]]; then
+              printf '::error::haskell requirement was missing or invalid: %s\n' "$HASKELL_REQUIRED"
+            fi
+
             exit 1
           fi

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -70,10 +70,26 @@ jobs:
                   ! "$base_sha" =~ ^0+$ ]] && \
                 git cat-file -e "${base_sha}^{commit}" 2>/dev/null && \
                 git cat-file -e "${head_sha}^{commit}" 2>/dev/null; then
+              comparison_sha="$base_sha"
+              comparison_ready=true
+
+              if [[ "$EVENT_NAME" == 'pull_request' ]]; then
+                merge_base_sha=$(git merge-base "$base_sha" "$head_sha" 2>/dev/null || true)
+
+                if [[ "$merge_base_sha" =~ ^[0-9a-fA-F]{40}$ ]] && \
+                    git cat-file -e "${merge_base_sha}^{commit}" 2>/dev/null; then
+                  comparison_sha="$merge_base_sha"
+                else
+                  comparison_ready=false
+                  haskell_reason='Haskell runs: no trusted pull-request merge base was available.'
+                fi
+              fi
+
               changed_paths_file='.ai4x/local/ci/changed-paths'
               mkdir -p "$(dirname "$changed_paths_file")"
 
-              if git diff --name-only --no-renames -z "$base_sha" "$head_sha" > "$changed_paths_file"; then
+              if [[ "$comparison_ready" == true ]] && \
+                  git diff --name-only --no-renames -z "$comparison_sha" "$head_sha" > "$changed_paths_file"; then
                 changed_path_count=0
                 documentation_only=true
                 first_technical_path=''
@@ -98,7 +114,7 @@ jobs:
                     haskell_reason="Haskell runs: changed path $quoted_path is technical or unknown."
                   fi
                 fi
-              else
+              elif [[ "$comparison_ready" == true ]]; then
                 haskell_reason='Haskell runs: the changed-path comparison failed.'
               fi
             else

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [trunk]
   pull_request:
-    branches: [trunk, chore/172-visible-ci-jobs]
+    branches: [trunk]
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [trunk]
   pull_request:
-    branches: [trunk]
+    branches: [trunk, chore/172-visible-ci-jobs]
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -11,15 +11,160 @@ permissions:
   contents: read
 
 jobs:
-  verify:
+  structure:
+    name: structure
+    runs-on: ubuntu-latest
+    outputs:
+      haskell_required: ${{ steps.changes.outputs.haskell_required }}
+      haskell_reason: ${{ steps.changes.outputs.haskell_reason }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - name: Classify changed paths
+        id: changes
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          EVENT_BEFORE: ${{ github.event.before }}
+          EVENT_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          EVENT_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          CURRENT_SHA: ${{ github.sha }}
+        run: |
+          set -u
+
+          is_documentation_path() {
+            case "$1" in
+              AGENTS.md | CODE_OF_CONDUCT.md | CONTRIBUTING.md | GOVERNANCE.md | LICENSING.md | README.md | SECURITY.md | \
+                .ai4x/*.md | .github/copilot-instructions.md | doc/*.md)
+                return 0
+                ;;
+              *)
+                return 1
+                ;;
+            esac
+          }
+
+          haskell_required=true
+          haskell_reason='Haskell runs: changed paths were not proven documentation-only.'
+          base_sha=''
+          head_sha=''
+
+          case "$EVENT_NAME" in
+            pull_request)
+              base_sha="$EVENT_BASE_SHA"
+              head_sha="$EVENT_HEAD_SHA"
+              ;;
+            push)
+              base_sha="$EVENT_BEFORE"
+              head_sha="$CURRENT_SHA"
+              ;;
+            *)
+              haskell_reason="Haskell runs: event '$EVENT_NAME' has no trusted changed-path comparison."
+              ;;
+          esac
+
+          if [[ "$EVENT_NAME" == 'pull_request' || "$EVENT_NAME" == 'push' ]]; then
+            if [[ "$base_sha" =~ ^[0-9a-fA-F]{40}$ && \
+                  "$head_sha" =~ ^[0-9a-fA-F]{40}$ && \
+                  ! "$base_sha" =~ ^0+$ ]] && \
+                git cat-file -e "${base_sha}^{commit}" 2>/dev/null && \
+                git cat-file -e "${head_sha}^{commit}" 2>/dev/null; then
+              changed_paths_file='.ai4x/local/ci/changed-paths'
+              mkdir -p "$(dirname "$changed_paths_file")"
+
+              if git diff --name-only --no-renames -z "$base_sha" "$head_sha" > "$changed_paths_file"; then
+                changed_path_count=0
+                documentation_only=true
+                first_technical_path=''
+
+                while IFS= read -r -d '' path; do
+                  ((changed_path_count += 1))
+
+                  if [[ -z "$first_technical_path" ]] && ! is_documentation_path "$path"; then
+                    documentation_only=false
+                    first_technical_path="$path"
+                  fi
+                done < "$changed_paths_file"
+
+                if (( changed_path_count == 0 )); then
+                  haskell_reason='Haskell runs: the trusted comparison contained no changed paths.'
+                else
+                  if [[ "$documentation_only" == true ]]; then
+                    haskell_required=false
+                    haskell_reason="Haskell skips: all $changed_path_count changed path(s) are explicitly documentation-only."
+                  else
+                    printf -v quoted_path '%q' "$first_technical_path"
+                    haskell_reason="Haskell runs: changed path $quoted_path is technical or unknown."
+                  fi
+                fi
+              else
+                haskell_reason='Haskell runs: the changed-path comparison failed.'
+              fi
+            else
+              haskell_reason='Haskell runs: comparison SHAs were missing, invalid, or unavailable.'
+            fi
+          fi
+
+          {
+            printf 'haskell_required=%s\n' "$haskell_required"
+            printf 'haskell_reason=%s\n' "$haskell_reason"
+          } >> "$GITHUB_OUTPUT"
+
+          {
+            printf '### Haskell selection\n\n'
+            printf -- '- Required: `%s`\n' "$haskell_required"
+            printf -- '- Reason: %s\n' "$haskell_reason"
+          } >> "$GITHUB_STEP_SUMMARY"
+      - name: Verify structure
+        run: make structure-check
+
+  licensing:
+    name: licensing
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
+      - name: Install REUSE
+        run: pipx install "reuse==6.2.0"
+      - name: Verify licensing
+        run: make licensing-check
+
+  haskell:
+    name: haskell
+    needs: structure
+    if: ${{ always() && needs.structure.outputs.haskell_required == 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
       - uses: haskell-actions/setup@v2
         with:
           ghc-version: 9.10.3
           cabal-version: 3.16.1.0
-      - name: Install REUSE
-        run: pipx install "reuse==6.2.0"
-      - name: Verify
-        run: make verify
+      - name: Verify Haskell
+        run: make haskell-check
+
+  verify:
+    name: verify
+    needs: [structure, licensing, haskell]
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify required jobs
+        env:
+          STRUCTURE_RESULT: ${{ needs.structure.result }}
+          LICENSING_RESULT: ${{ needs.licensing.result }}
+          HASKELL_RESULT: ${{ needs.haskell.result }}
+          HASKELL_REQUIRED: ${{ needs.structure.outputs.haskell_required }}
+        run: |
+          set -euo pipefail
+
+          [[ "$STRUCTURE_RESULT" == 'success' ]]
+          [[ "$LICENSING_RESULT" == 'success' ]]
+
+          if [[ "$HASKELL_REQUIRED" == 'true' ]]; then
+            [[ "$HASKELL_RESULT" == 'success' ]]
+          elif [[ "$HASKELL_REQUIRED" == 'false' ]]; then
+            [[ "$HASKELL_RESULT" == 'skipped' ]]
+          else
+            exit 1
+          fi

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -18,7 +18,7 @@ jobs:
       haskell_required: ${{ steps.changes.outputs.haskell_required }}
       haskell_reason: ${{ steps.changes.outputs.haskell_reason }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
       - name: Classify changed paths
@@ -49,7 +49,13 @@ jobs:
             local path
 
             for path in \
+              AGENTS.md \
+              CODE_OF_CONDUCT.md \
+              CONTRIBUTING.md \
+              GOVERNANCE.md \
+              LICENSING.md \
               README.md \
+              SECURITY.md \
               .ai4x/context/architecture.md \
               .github/copilot-instructions.md \
               doc/reference/example.md; do
@@ -171,7 +177,7 @@ jobs:
     name: licensing
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Install REUSE
         run: pipx install "reuse==6.2.0"
       - name: Verify licensing
@@ -183,8 +189,8 @@ jobs:
     if: ${{ always() && needs.structure.outputs.haskell_required == 'true' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: haskell-actions/setup@v2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: haskell-actions/setup@cd0d9bdd65b20557f41bea4dbe43d0b5fbbfe553 # v2.11.0
         with:
           ghc-version: 9.10.3
           cabal-version: 3.16.1.0

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -156,15 +156,42 @@ jobs:
           HASKELL_RESULT: ${{ needs.haskell.result }}
           HASKELL_REQUIRED: ${{ needs.structure.outputs.haskell_required }}
         run: |
-          set -euo pipefail
+          set -u
 
-          [[ "$STRUCTURE_RESULT" == 'success' ]]
-          [[ "$LICENSING_RESULT" == 'success' ]]
+          verification_failed=false
+
+          if [[ "$STRUCTURE_RESULT" != 'success' ]]; then
+            printf '::error::structure concluded %s\n' "$STRUCTURE_RESULT"
+            verification_failed=true
+          fi
+
+          if [[ "$LICENSING_RESULT" != 'success' ]]; then
+            printf '::error::licensing concluded %s\n' "$LICENSING_RESULT"
+            verification_failed=true
+          fi
 
           if [[ "$HASKELL_REQUIRED" == 'true' ]]; then
-            [[ "$HASKELL_RESULT" == 'success' ]]
+            if [[ "$HASKELL_RESULT" != 'success' ]]; then
+              printf '::error::haskell was required but concluded %s\n' "$HASKELL_RESULT"
+              verification_failed=true
+            fi
           elif [[ "$HASKELL_REQUIRED" == 'false' ]]; then
-            [[ "$HASKELL_RESULT" == 'skipped' ]]
+            if [[ "$HASKELL_RESULT" != 'skipped' ]]; then
+              printf '::error::haskell was not required but concluded %s\n' "$HASKELL_RESULT"
+              verification_failed=true
+            fi
           else
+            printf '::error::haskell requirement was missing or invalid: %s\n' "$HASKELL_REQUIRED"
+            verification_failed=true
+          fi
+
+          {
+            printf '### Verification aggregate\n\n'
+            printf -- '- `structure`: `%s`\n' "$STRUCTURE_RESULT"
+            printf -- '- `licensing`: `%s`\n' "$LICENSING_RESULT"
+            printf -- '- `haskell`: `%s` (required: `%s`)\n' "$HASKELL_RESULT" "$HASKELL_REQUIRED"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          if [[ "$verification_failed" == true ]]; then
             exit 1
           fi


### PR DESCRIPTION
## Summary

- expose `structure`, `licensing`, and `haskell` as separate CI jobs
- skip Haskell only for the approved documentation allowlist and fail closed for unknown or untrustworthy comparisons
- publish the selection reason in the `structure` job summary
- preserve the protected `verify` context as a strict aggregate job
- pin current supported `actions/checkout` v7.0.1 and `haskell-actions/setup` v2.11.0 to immutable commits

## Verification

- `actionlint .github/workflows/verify.yml`
- `git diff --check`
- `make verify`
- historical documentation-only comparison: `haskell_required=false`
- historical documentation-only comparison with technical base drift: merge-base classification remains `haskell_required=false`
- historical Haskell comparison: `haskell_required=true`
- empty comparison and unsupported event: `haskell_required=true`
- versioned inline policy fixtures cover the documentation allowlist, unknown and technical paths, and all aggregate success/failure combinations
- base-drift documentation-only canary PR #175 on the authoritative classifier fixtures and aggregate decision: `structure` and `licensing` passed, `haskell` skipped, `verify` passed ([run 32644502205](https://github.com/normenmueller/ai4X/actions/runs/32644502205))

Closes #172
