### PR TITLE
Validate the documentation-only CI path

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 ai4X is an operating model for explicit, reusable, and host-independent agentic
 AI work—agentic cognition engineering (ACE).
 
+This temporary documentation-only line validates the #172 CI path and is not intended for merge.
+
 The project is rebuilding from a deliberately small, greenfield baseline.
 Product capabilities will return as focused, verified vertical slices rather
 than as a wholesale migration of the previous prototype.


### PR DESCRIPTION
## Purpose

This temporary PR proves the documentation-only path required by #172 against the implementation branch.

Expected checks:

- `structure`: success, with a job summary explaining the documentation-only classification
- `licensing`: success
- `haskell`: skipped, with no GHC or Cabal setup
- `verify`: success, preserving the aggregate required-check semantics

This PR is evidence only and must not be merged.
