### PR TITLE
Prove factory-reset recovery for the ai4X project instance

### DIFF
--- a/.ai4x/CONTEXT.md
+++ b/.ai4x/CONTEXT.md
@@ -4,6 +4,7 @@ Start with [BEHAVIOR.md](BEHAVIOR.md). Then load only what the task needs:
 
 - [context/architecture.md](context/architecture.md) for structure and authority boundaries;
 - [context/domain-language.md](context/domain-language.md) for core terminology;
+- [operations/work-continuity.md](operations/work-continuity.md) for factory-reset readiness and recovery;
 - the owning GitHub Issue for requirements, status, and acceptance criteria;
 - the affected source, tests, and nearby documentation for implementation work.
 

--- a/.ai4x/bindings/work-continuity.md
+++ b/.ai4x/bindings/work-continuity.md
@@ -1,0 +1,28 @@
+# Work-continuity Target Binding
+
+The ai4X project instance currently requires one logical
+`SyncedDirectoryTarget` for inert recovery material. The concrete provider and
+absolute target path are machine-local facts and must not be committed.
+
+Record the active machine's target root as the only line in:
+
+```text
+.ai4x/local/work-continuity/target
+```
+
+The target must provide this bounded layout:
+
+```text
+work-continuity/
+├─ README.md
+├─ CURRENT
+├─ baseline/
+└─ rolling/
+   ├─ slot-a/
+   ├─ slot-b/
+   └─ slot-c/
+```
+
+`CURRENT` contains one relative rolling-slot name such as `rolling/slot-a`.
+The target remains outside the active repository and must never be used as a
+working directory, tracked authority, or destination for build output.

--- a/.ai4x/operations/work-continuity.md
+++ b/.ai4x/operations/work-continuity.md
@@ -7,6 +7,10 @@ and supplies evidence for the future Portfolio offering discussed in
 [Issue #180](https://github.com/normenmueller/ai4X/issues/180). It is not a
 released `WorkContinuityBundle` or a stable product API.
 
+The scripts under `util/work-continuity/` are repository tooling only. #180
+must retire them after the released Portfolio implementation under `src/`
+proves the equivalent project path.
+
 ## Readiness invariant
 
 ```text
@@ -24,8 +28,10 @@ workspace or a competing project authority.
 ## Project-instance boundary
 
 ```text
+.ai4x/operations/work-continuity.md
+  tracked agent-facing rules and operating procedure
+
 .ai4x/operations/work-continuity/
-  README.md       tracked rules and operating procedure
   INCLUDE.txt     explicit local-continuity inventory
   RECOVERY.md     cold-start recovery procedure
 

--- a/.ai4x/operations/work-continuity/INCLUDE.txt
+++ b/.ai4x/operations/work-continuity/INCLUDE.txt
@@ -1,0 +1,13 @@
+.ai4x/local/session-scratch/102/epic-review.md
+.ai4x/local/session-scratch/103/command-surface-review.md
+.ai4x/local/session-scratch/103/curation-functional-contract.md
+.ai4x/local/session-scratch/103/epic-body.md
+.ai4x/local/session-scratch/103/first-story-body.md
+.ai4x/local/session-scratch/103/reference/ai4x-logo/ai4X Logo.jpg
+.ai4x/local/session-scratch/103/reference/complete-sfe-run-interaction.md
+.ai4x/local/session-scratch/103/reference/complete-sfe-run-interaction.png
+.ai4x/local/session-scratch/103/reference/complete-sfe-run-interaction.tex
+.ai4x/local/session-scratch/103/refinement-comment.md
+.ai4x/local/session-scratch/180/work-continuity-portfolio-and-project-instance.md
+.ai4x/local/session-scratch/CURRENT-HANDOFF.md
+.ai4x/local/session-scratch/NEXT-SESSION-PROMPT.md

--- a/.ai4x/operations/work-continuity/README.md
+++ b/.ai4x/operations/work-continuity/README.md
@@ -1,0 +1,79 @@
+# ai4X Project Work Continuity
+
+This tracked procedure makes the concrete ai4X project instance recoverable
+after loss or replacement of its workstation. It is a provisional, manual
+#eyodf bootstrap for [Issue #181](https://github.com/normenmueller/ai4X/issues/181)
+and supplies evidence for the future Portfolio offering discussed in
+[Issue #180](https://github.com/normenmueller/ai4X/issues/180). It is not a
+released `WorkContinuityBundle` or a stable product API.
+
+## Readiness invariant
+
+```text
+RemoteCheckpoint<Verified>
+  + LocalContinuity<None | Recoverable>
+  + RestoreProof<Passed>
+  = WorkState<Recoverable>
+```
+
+The configured Git remote is the sole authority for tracked work. An external
+recovery target contains only inert fallback material for explicitly selected
+local continuity state and additional local Git history. It is never an active
+workspace or a competing project authority.
+
+## Project-instance boundary
+
+```text
+.ai4x/operations/work-continuity/
+  README.md       tracked rules and operating procedure
+  INCLUDE.txt     explicit local-continuity inventory
+  RECOVERY.md     cold-start recovery procedure
+
+.ai4x/bindings/work-continuity.md
+  tracked logical target requirement; no machine-local path
+
+util/work-continuity/
+  provisional checkpoint and verification tools
+
+.ai4x/local/work-continuity/
+  machine-local target binding, staging and locks
+
+external target/
+  README.md, CURRENT, baseline/, rolling/
+```
+
+## Checkpoint
+
+1. Require a clean tracked worktree and exact equality between `HEAD` and its
+   configured upstream.
+2. Review `INCLUDE.txt`. Only necessary local continuity files may be listed.
+3. Prepare a new slot below `.ai4x/local/work-continuity/staging/`:
+
+   ```sh
+   util/work-continuity/create-checkpoint.sh \
+     . \
+     .ai4x/local/work-continuity/staging/slot-a \
+     slot-a
+   ```
+
+4. Copy the verified prepared slot to an unused or separately authorized
+   eligible rolling slot at the bound external target.
+5. Verify the copied slot with
+   `util/work-continuity/verify-checkpoint.sh CHECKPOINT_DIRECTORY`.
+6. Replace `CURRENT` only after the copied slot and a proportionate restore
+   have passed verification.
+
+Never replace the preserved baseline, the current rolling slot, or the last
+verified recovery state. A replacement is prepared and verified before an
+older eligible slot is removed.
+
+## Inclusion policy
+
+`INCLUDE.txt` is the complete allowlist. Every entry must be a regular,
+non-symlinked file below `.ai4x/local/`. Credentials, secrets, unrelated
+projects, provider-private state, unnecessary transcripts, caches, build
+outputs and downloaded tools remain excluded.
+
+Refresh the rolling recovery set after a coherent tracked checkpoint whenever
+necessary local continuity state materially changes. Do not checkpoint every
+edit mechanically.

--- a/.ai4x/operations/work-continuity/RECOVERY.md
+++ b/.ai4x/operations/work-continuity/RECOVERY.md
@@ -1,0 +1,52 @@
+# ai4X Work-continuity Recovery
+
+## Normal reconstruction
+
+Read `MANIFEST.txt` from the slot named by the external target's `CURRENT`
+pointer. Clone its `repository`, switch to its `branch`, and verify that the
+checked-out revision equals both `head` and the configured upstream revision.
+Git remains the normal authority for tracked work.
+
+```sh
+git clone REPOSITORY ai4X
+cd ai4X
+git switch BRANCH
+git rev-parse HEAD
+git rev-parse '@{upstream}'
+```
+
+## Verify the fallback
+
+Use the verifier supplied by the fresh clone, not a script recovered from the
+slot:
+
+```sh
+util/work-continuity/verify-checkpoint.sh CHECKPOINT_DIRECTORY
+```
+
+This verifies checksums, Git-bundle integrity, archive readability, manifest
+coherence, and exact inclusion inventory.
+
+## Restore selected local continuity
+
+Restore local state only after the tracked checkout has been reconstructed and
+only when the manifest-listed state is still needed:
+
+```sh
+tar -xzf CHECKPOINT_DIRECTORY/local-continuity.tar.gz -C ai4X
+```
+
+Recreate the machine-local target binding described by
+`.ai4x/bindings/work-continuity.md`; never recover an old absolute path as a
+project fact.
+
+Use `all-refs.bundle` only if GitHub is unavailable or additional local Git
+history is required:
+
+```sh
+git clone --branch BRANCH CHECKPOINT_DIRECTORY/all-refs.bundle ai4X
+```
+
+Do not restore build output, caches, downloaded tools, credentials, or
+provider-owned private state. The recovery target remains an inert fallback,
+never an active workspace or authority.

--- a/.ai4x/records/evidence/assurance/work-continuity/factory-reset-restore-proof.md
+++ b/.ai4x/records/evidence/assurance/work-continuity/factory-reset-restore-proof.md
@@ -1,0 +1,53 @@
+# Factory-reset Restore Proof
+
+- Issue: [#181](https://github.com/normenmueller/ai4X/issues/181)
+- Observed: 2026-08-26
+- Bootstrap revision: `600cde10d33d436e7e34973314bb54977ea73e9e`
+
+## Claim
+
+The concrete ai4X project instance can be reconstructed from its authoritative
+Git remote and its explicitly selected local continuity archive without access
+to the original working copy.
+
+## Evidence
+
+1. A new checkout was cloned from `git@github.com:normenmueller/ai4X.git` at
+   branch `chore/181-factory-reset-recovery`.
+2. The fresh checkout resolved both `HEAD` and its upstream to exact revision
+   `600cde10d33d436e7e34973314bb54977ea73e9e`.
+3. The verifier supplied only by that fresh checkout accepted the prepared
+   `ai4x-project-work-continuity-bootstrap-v1` recovery set:
+   - the checksum manifest named exactly the expected five protected files;
+   - every protected digest matched;
+   - the Git bundle was complete and its branch and trunk refs matched the
+     checkpoint manifest;
+   - the checkpoint manifest had exactly the required fields and values;
+   - the local archive exactly matched the tracked inclusion policy and
+     contained only regular, normalized `.ai4x/local/` members.
+4. The selected local archive was extracted only after verification. The
+   restored checkout contained the current handoff and the #103 Curation
+   functional contract.
+5. The restored checkout retained a clean tracked worktree and passed complete
+   `make verify`: architecture checks, work-continuity mutation tests, REUSE,
+   Haskell build and tests with `-Werror`, Haddock, and all Cabal checks.
+
+The verified `SHA256SUMS` document had digest
+`1b72631c19e406fd20d10de46d02c0cd01d9e92f5479c39551683f20d3a4d42a`.
+The machine-local provider path is deliberately redacted and is not a tracked
+project fact.
+
+## Negative evidence
+
+Tracked mutation tests reject truncated or externally addressed checksum
+manifests, bundle/manifest disagreement, path traversal, duplicate inclusion,
+archive symlinks, source paths crossing parent symlinks, and repository URLs
+that may contain credentials.
+
+## Limits
+
+- This proves project-instance reconstruction, not provider durability.
+- The scripts are provisional repository tooling and not the released #180
+  Portfolio implementation.
+- Evidence establishes a claim; it grants no merge, acceptance, or lifecycle
+  authority.

--- a/.ai4x/records/evidence/assurance/work-continuity/factory-reset-restore-proof.md
+++ b/.ai4x/records/evidence/assurance/work-continuity/factory-reset-restore-proof.md
@@ -1,8 +1,8 @@
 # Factory-reset Restore Proof
 
 - Issue: [#181](https://github.com/normenmueller/ai4X/issues/181)
-- Observed: 2026-08-26
-- Bootstrap revision: `600cde10d33d436e7e34973314bb54977ea73e9e`
+- Observed: 2026-08-27
+- Bootstrap revision: `0797d32576c7a32ab6439cca36aec0f0765107e1`
 
 ## Claim
 
@@ -15,7 +15,7 @@ to the original working copy.
 1. A new checkout was cloned from `git@github.com:normenmueller/ai4X.git` at
    branch `chore/181-factory-reset-recovery`.
 2. The fresh checkout resolved both `HEAD` and its upstream to exact revision
-   `600cde10d33d436e7e34973314bb54977ea73e9e`.
+   `0797d32576c7a32ab6439cca36aec0f0765107e1`.
 3. The verifier supplied only by that fresh checkout accepted the prepared
    `ai4x-project-work-continuity-bootstrap-v1` recovery set:
    - the checksum manifest named exactly the expected five protected files;
@@ -28,12 +28,15 @@ to the original working copy.
 4. The selected local archive was extracted only after verification. The
    restored checkout contained the current handoff and the #103 Curation
    functional contract.
-5. The restored checkout retained a clean tracked worktree and passed complete
+5. Before any local restore, the clean checkout passed the self-contained
+   work-continuity mutation tests without relying on `.ai4x/local/` from the
+   source workspace.
+6. The restored checkout retained a clean tracked worktree and passed complete
    `make verify`: architecture checks, work-continuity mutation tests, REUSE,
    Haskell build and tests with `-Werror`, Haddock, and all Cabal checks.
 
 The verified `SHA256SUMS` document had digest
-`1b72631c19e406fd20d10de46d02c0cd01d9e92f5479c39551683f20d3a4d42a`.
+`cb224fc8d865f88523025ff6c3e8f0156004b956983bfe88e395b2b3187efb3d`.
 The machine-local provider path is deliberately redacted and is not a tracked
 project fact.
 
@@ -42,7 +45,8 @@ project fact.
 Tracked mutation tests reject truncated or externally addressed checksum
 manifests, bundle/manifest disagreement, path traversal, duplicate inclusion,
 archive symlinks, source paths crossing parent symlinks, and repository URLs
-that may contain credentials.
+that may contain credentials. Source validation also rejects a symlink at the
+`.ai4x/local` directory boundary itself.
 
 ## Limits
 

--- a/.ai4x/records/receipts/work-continuity/factory-reset-readiness.md
+++ b/.ai4x/records/receipts/work-continuity/factory-reset-readiness.md
@@ -1,0 +1,30 @@
+# Factory-reset Readiness Receipt
+
+- Issue: [#181](https://github.com/normenmueller/ai4X/issues/181)
+- Observed: 2026-08-26
+- Evidence: [Factory-reset Restore Proof](../../../evidence/assurance/work-continuity/factory-reset-restore-proof.md)
+
+```text
+RemoteCheckpoint<Verified>
+  revision = 600cde10d33d436e7e34973314bb54977ea73e9e
+
+LocalContinuity<Recoverable>
+  schema = ai4x-project-work-continuity-bootstrap-v1
+  protected-manifest-sha256 = 1b72631c19e406fd20d10de46d02c0cd01d9e92f5479c39551683f20d3a4d42a
+
+RestoreProof<Passed>
+  fresh-clone = passed
+  checkpoint-verification = passed
+  selected-local-restore = passed
+  repository-verification = passed
+
+WorkState<Recoverable>
+```
+
+The observed rolling-slot name is historical evidence only; the external
+`CURRENT` pointer remains the authority for the active recovery slot. Concrete
+provider and machine-local target paths are intentionally absent.
+
+This receipt records verification evidence. It does not make the recovery
+target authoritative and grants no Portfolio adoption, merge, Issue closure,
+or other Product Owner authority.

--- a/.ai4x/records/receipts/work-continuity/factory-reset-readiness.md
+++ b/.ai4x/records/receipts/work-continuity/factory-reset-readiness.md
@@ -1,16 +1,16 @@
 # Factory-reset Readiness Receipt
 
 - Issue: [#181](https://github.com/normenmueller/ai4X/issues/181)
-- Observed: 2026-08-26
+- Observed: 2026-08-27
 - Evidence: [Factory-reset Restore Proof](../../../evidence/assurance/work-continuity/factory-reset-restore-proof.md)
 
 ```text
 RemoteCheckpoint<Verified>
-  revision = 600cde10d33d436e7e34973314bb54977ea73e9e
+  revision = 0797d32576c7a32ab6439cca36aec0f0765107e1
 
 LocalContinuity<Recoverable>
   schema = ai4x-project-work-continuity-bootstrap-v1
-  protected-manifest-sha256 = 1b72631c19e406fd20d10de46d02c0cd01d9e92f5479c39551683f20d3a4d42a
+  protected-manifest-sha256 = cb224fc8d865f88523025ff6c3e8f0156004b956983bfe88e395b2b3187efb3d
 
 RestoreProof<Passed>
   fresh-clone = passed

--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,12 @@ REQUIRED_FILES := \
 	.ai4x/.gitignore \
 	.ai4x/BEHAVIOR.md \
 	.ai4x/CONTEXT.md \
+	.ai4x/bindings/work-continuity.md \
 	.ai4x/context/architecture.md \
 	.ai4x/context/domain-language.md \
+	.ai4x/operations/work-continuity/INCLUDE.txt \
+	.ai4x/operations/work-continuity/README.md \
+	.ai4x/operations/work-continuity/RECOVERY.md \
 	.github/CODEOWNERS \
 	.github/copilot-instructions.md \
 	.github/workflows/verify.yml \
@@ -66,7 +70,9 @@ REQUIRED_FILES := \
 	src/foundation/generation/tst/AI4X/Generation/ProtocolTest.hs \
 	src/foundation/generation/tst/AI4X/Generation/SuccessTest.hs \
 	util/repository/verify-foundation.sh \
-	util/repository/tst/verify-foundation.sh
+	util/repository/tst/verify-foundation.sh \
+	util/work-continuity/create-checkpoint.sh \
+	util/work-continuity/verify-checkpoint.sh
 
 REQUIRED_DIRS := \
 	.ai4x/agents \
@@ -120,7 +126,8 @@ REQUIRED_DIRS := \
 	util/assurance \
 	util/documentation \
 	util/repository \
-	util/repository/tst
+	util/repository/tst \
+	util/work-continuity
 
 LEGACY_DIRS := \
 	.ai4x/planning \
@@ -161,6 +168,8 @@ structure-check:
 	@test ! -e cabal.project.freeze || { echo '[ai4x] ERROR Cabal freeze file belongs under src/' >&2; exit 2; }
 	@test ! -e hie.yaml || { echo '[ai4x] ERROR HLS configuration belongs under src/' >&2; exit 2; }
 	@test -z "$$(find . -maxdepth 1 -name '*.cabal' -print -quit)" || { echo '[ai4x] ERROR Cabal packages belong under src/' >&2; exit 2; }
+	@test -x util/work-continuity/create-checkpoint.sh || { echo '[ai4x] ERROR checkpoint tool is not executable' >&2; exit 2; }
+	@test -x util/work-continuity/verify-checkpoint.sh || { echo '[ai4x] ERROR checkpoint verifier is not executable' >&2; exit 2; }
 	@./util/repository/verify-foundation.sh
 	@./util/repository/tst/verify-foundation.sh
 

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ REQUIRED_FILES := \
 	.ai4x/context/architecture.md \
 	.ai4x/context/domain-language.md \
 	.ai4x/operations/work-continuity/INCLUDE.txt \
-	.ai4x/operations/work-continuity/README.md \
+	.ai4x/operations/work-continuity.md \
 	.ai4x/operations/work-continuity/RECOVERY.md \
 	.github/CODEOWNERS \
 	.github/copilot-instructions.md \
@@ -71,8 +71,10 @@ REQUIRED_FILES := \
 	src/foundation/generation/tst/AI4X/Generation/SuccessTest.hs \
 	util/repository/verify-foundation.sh \
 	util/repository/tst/verify-foundation.sh \
+	util/work-continuity/common.sh \
 	util/work-continuity/create-checkpoint.sh \
-	util/work-continuity/verify-checkpoint.sh
+	util/work-continuity/verify-checkpoint.sh \
+	util/work-continuity/tst/verify-work-continuity.sh
 
 REQUIRED_DIRS := \
 	.ai4x/agents \
@@ -127,7 +129,8 @@ REQUIRED_DIRS := \
 	util/documentation \
 	util/repository \
 	util/repository/tst \
-	util/work-continuity
+	util/work-continuity \
+	util/work-continuity/tst
 
 LEGACY_DIRS := \
 	.ai4x/planning \
@@ -170,8 +173,10 @@ structure-check:
 	@test -z "$$(find . -maxdepth 1 -name '*.cabal' -print -quit)" || { echo '[ai4x] ERROR Cabal packages belong under src/' >&2; exit 2; }
 	@test -x util/work-continuity/create-checkpoint.sh || { echo '[ai4x] ERROR checkpoint tool is not executable' >&2; exit 2; }
 	@test -x util/work-continuity/verify-checkpoint.sh || { echo '[ai4x] ERROR checkpoint verifier is not executable' >&2; exit 2; }
+	@test -x util/work-continuity/tst/verify-work-continuity.sh || { echo '[ai4x] ERROR work-continuity tests are not executable' >&2; exit 2; }
 	@./util/repository/verify-foundation.sh
 	@./util/repository/tst/verify-foundation.sh
+	@./util/work-continuity/tst/verify-work-continuity.sh
 
 licensing-check:
 	@command -v reuse >/dev/null 2>&1 || { echo '[ai4x] ERROR reuse is required' >&2; exit 2; }

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,8 @@ REQUIRED_FILES := \
 	.ai4x/operations/work-continuity/INCLUDE.txt \
 	.ai4x/operations/work-continuity.md \
 	.ai4x/operations/work-continuity/RECOVERY.md \
+	.ai4x/records/evidence/assurance/work-continuity/factory-reset-restore-proof.md \
+	.ai4x/records/receipts/work-continuity/factory-reset-readiness.md \
 	.github/CODEOWNERS \
 	.github/copilot-instructions.md \
 	.github/workflows/verify.yml \
@@ -86,9 +88,11 @@ REQUIRED_DIRS := \
 	.ai4x/intent \
 	.ai4x/operations \
 	.ai4x/records/evidence/assurance \
+	.ai4x/records/evidence/assurance/work-continuity \
 	.ai4x/records/evidence/reviews \
 	.ai4x/records/provenance \
 	.ai4x/records/receipts \
+	.ai4x/records/receipts/work-continuity \
 	.codex \
 	.github/agents \
 	.github/ISSUE_TEMPLATE \

--- a/util/work-continuity/common.sh
+++ b/util/work-continuity/common.sh
@@ -1,0 +1,79 @@
+#!/bin/sh
+
+validate_include_syntax() (
+  include_file=$1
+
+  if [ ! -s "$include_file" ]; then
+    echo "inclusion manifest is missing or empty: $include_file" >&2
+    exit 65
+  fi
+
+  if ! LC_ALL=C sort -u "$include_file" | cmp -s - "$include_file"; then
+    echo "inclusion manifest must be sorted and contain no duplicates" >&2
+    exit 65
+  fi
+
+  while IFS= read -r included_path; do
+    if ! printf '%s\n' "$included_path" | LC_ALL=C grep -Eq '^\.ai4x/local/[A-Za-z0-9._ /-]+$'; then
+      echo "included path contains unsupported characters: $included_path" >&2
+      exit 65
+    fi
+
+    case "$included_path" in
+      .ai4x/local/*) ;;
+      *)
+        echo "included path is outside .ai4x/local: $included_path" >&2
+        exit 65
+        ;;
+    esac
+
+    case "$included_path" in
+      *//*|*/./*|*/../*|*/.|*/..)
+        echo "included path is not lexically normalized: $included_path" >&2
+        exit 65
+        ;;
+    esac
+  done < "$include_file"
+)
+
+validate_local_sources() (
+  repository=$1
+  include_file=$2
+
+  validate_include_syntax "$include_file"
+
+  while IFS= read -r included_path; do
+    relative_path=${included_path#.ai4x/local/}
+    prefix="$repository/.ai4x/local"
+    previous_ifs=$IFS
+    set -f
+    IFS=/
+    set -- $relative_path
+    IFS=$previous_ifs
+
+    for component in "$@"; do
+      prefix="$prefix/$component"
+      if [ -L "$prefix" ]; then
+        echo "included path crosses a symlink: $included_path" >&2
+        exit 65
+      fi
+    done
+
+    if [ ! -f "$repository/$included_path" ]; then
+      echo "included path is missing or not a regular file: $included_path" >&2
+      exit 66
+    fi
+  done < "$include_file"
+)
+
+require_safe_repository_url() (
+  repository_url=$1
+
+  case "$repository_url" in
+    git@github.com:normenmueller/ai4X.git|https://github.com/normenmueller/ai4X.git) ;;
+    *)
+      echo "repository URL is unsupported or may contain credentials" >&2
+      exit 65
+      ;;
+  esac
+)

--- a/util/work-continuity/common.sh
+++ b/util/work-continuity/common.sh
@@ -39,12 +39,18 @@ validate_include_syntax() (
 validate_local_sources() (
   repository=$1
   include_file=$2
+  local_root="$repository/.ai4x/local"
 
   validate_include_syntax "$include_file"
 
+  if [ -L "$local_root" ] || [ ! -d "$local_root" ]; then
+    echo ".ai4x/local must be a real directory boundary" >&2
+    exit 65
+  fi
+
   while IFS= read -r included_path; do
     relative_path=${included_path#.ai4x/local/}
-    prefix="$repository/.ai4x/local"
+    prefix=$local_root
     previous_ifs=$IFS
     set -f
     IFS=/

--- a/util/work-continuity/create-checkpoint.sh
+++ b/util/work-continuity/create-checkpoint.sh
@@ -9,6 +9,8 @@ fi
 repository=$1
 output_directory=$2
 slot=$3
+script_directory=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+. "$script_directory/common.sh"
 
 case "$slot" in
   slot-a|slot-b|slot-c) ;;
@@ -33,14 +35,19 @@ head_revision=$(git -C "$repository" rev-parse HEAD)
 upstream=$(git -C "$repository" rev-parse --abbrev-ref --symbolic-full-name '@{upstream}')
 upstream_revision=$(git -C "$repository" rev-parse "$upstream")
 origin_trunk=$(git -C "$repository" rev-parse refs/remotes/origin/trunk)
-origin_url=$(git -C "$repository" remote get-url origin)
+repository_url=$(git -C "$repository" remote get-url origin)
 created_at=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
 include_file="$repository/.ai4x/operations/work-continuity/INCLUDE.txt"
 recovery_file="$repository/.ai4x/operations/work-continuity/RECOVERY.md"
 verifier="$repository/util/work-continuity/verify-checkpoint.sh"
 
-if [ "$head_revision" != "$upstream_revision" ]; then
-  echo "HEAD does not equal its upstream" >&2
+if [ -z "$branch" ] || ! git check-ref-format --branch "$branch" > /dev/null; then
+  echo "checkout has no valid branch" >&2
+  exit 65
+fi
+
+if [ "$upstream" != "origin/$branch" ] || [ "$head_revision" != "$upstream_revision" ]; then
+  echo "HEAD does not equal its expected origin upstream" >&2
   exit 65
 fi
 
@@ -51,44 +58,51 @@ for required_input in "$include_file" "$recovery_file" "$verifier"; do
   fi
 done
 
-while IFS= read -r included_path; do
-  case "$included_path" in
-    .ai4x/local/*) ;;
-    *)
-      echo "included path is outside .ai4x/local: $included_path" >&2
-      exit 65
-      ;;
-  esac
+require_safe_repository_url "$repository_url"
+validate_local_sources "$repository" "$include_file"
 
-  if [ ! -f "$repository/$included_path" ] || [ -L "$repository/$included_path" ]; then
-    echo "included path is missing, not regular, or a symlink: $included_path" >&2
-    exit 66
+output_parent=$(dirname -- "$output_directory")
+output_name=$(basename -- "$output_directory")
+mkdir -p "$output_parent"
+prepared_directory=$(mktemp -d "$output_parent/.${output_name}.prepared.XXXXXX")
+
+cleanup() {
+  if [ -n "${prepared_directory:-}" ]; then
+    case "$prepared_directory" in
+      "$output_parent"/."$output_name".prepared.*) rm -rf "$prepared_directory" ;;
+      *) echo "refusing unsafe prepared-output cleanup: $prepared_directory" >&2 ;;
+    esac
   fi
-done < "$include_file"
+}
+trap cleanup EXIT HUP INT TERM
 
-mkdir -p "$output_directory"
-git -C "$repository" bundle create "$output_directory/all-refs.bundle" --all
-tar -czf "$output_directory/local-continuity.tar.gz" -C "$repository" -T "$include_file"
-cp "$recovery_file" "$output_directory/RECOVERY.md"
-cp "$include_file" "$output_directory/INCLUDE.txt"
+git -C "$repository" bundle create "$prepared_directory/all-refs.bundle" --all
+tar -czf "$prepared_directory/local-continuity.tar.gz" -C "$repository" -T "$include_file"
+cp "$recovery_file" "$prepared_directory/RECOVERY.md"
+cp "$include_file" "$prepared_directory/INCLUDE.txt"
 
 printf '%s\n' \
   "schema=ai4x-project-work-continuity-bootstrap-v1" \
   "issue=181" \
   "slot=$slot" \
   "created_at=$created_at" \
-  "repository=$origin_url" \
+  "repository=$repository_url" \
   "branch=$branch" \
   "head=$head_revision" \
   "upstream=$upstream" \
   "upstream_head=$upstream_revision" \
   "origin_trunk=$origin_trunk" \
   "tracked_worktree=clean" \
-  > "$output_directory/MANIFEST.txt"
+  > "$prepared_directory/MANIFEST.txt"
 
 (
-  cd "$output_directory"
+  cd "$prepared_directory"
   shasum -a 256 all-refs.bundle local-continuity.tar.gz RECOVERY.md INCLUDE.txt MANIFEST.txt > SHA256SUMS
 )
 
-"$verifier" "$output_directory"
+"$verifier" "$prepared_directory"
+mv "$prepared_directory" "$output_directory"
+prepared_directory=
+trap - EXIT HUP INT TERM
+
+echo "prepared and verified: $output_directory"

--- a/util/work-continuity/create-checkpoint.sh
+++ b/util/work-continuity/create-checkpoint.sh
@@ -1,0 +1,94 @@
+#!/bin/sh
+set -eu
+
+if [ "$#" -ne 3 ]; then
+  echo "usage: $0 REPOSITORY OUTPUT_DIRECTORY SLOT" >&2
+  exit 64
+fi
+
+repository=$1
+output_directory=$2
+slot=$3
+
+case "$slot" in
+  slot-a|slot-b|slot-c) ;;
+  *)
+    echo "unsupported slot: $slot" >&2
+    exit 64
+    ;;
+esac
+
+if [ -e "$output_directory" ]; then
+  echo "output already exists: $output_directory" >&2
+  exit 73
+fi
+
+if [ -n "$(git -C "$repository" status --porcelain=v1 --untracked-files=no)" ]; then
+  echo "tracked worktree is not clean" >&2
+  exit 65
+fi
+
+branch=$(git -C "$repository" branch --show-current)
+head_revision=$(git -C "$repository" rev-parse HEAD)
+upstream=$(git -C "$repository" rev-parse --abbrev-ref --symbolic-full-name '@{upstream}')
+upstream_revision=$(git -C "$repository" rev-parse "$upstream")
+origin_trunk=$(git -C "$repository" rev-parse refs/remotes/origin/trunk)
+origin_url=$(git -C "$repository" remote get-url origin)
+created_at=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
+include_file="$repository/.ai4x/operations/work-continuity/INCLUDE.txt"
+recovery_file="$repository/.ai4x/operations/work-continuity/RECOVERY.md"
+verifier="$repository/util/work-continuity/verify-checkpoint.sh"
+
+if [ "$head_revision" != "$upstream_revision" ]; then
+  echo "HEAD does not equal its upstream" >&2
+  exit 65
+fi
+
+for required_input in "$include_file" "$recovery_file" "$verifier"; do
+  if [ ! -f "$required_input" ]; then
+    echo "missing work-continuity input: $required_input" >&2
+    exit 66
+  fi
+done
+
+while IFS= read -r included_path; do
+  case "$included_path" in
+    .ai4x/local/*) ;;
+    *)
+      echo "included path is outside .ai4x/local: $included_path" >&2
+      exit 65
+      ;;
+  esac
+
+  if [ ! -f "$repository/$included_path" ] || [ -L "$repository/$included_path" ]; then
+    echo "included path is missing, not regular, or a symlink: $included_path" >&2
+    exit 66
+  fi
+done < "$include_file"
+
+mkdir -p "$output_directory"
+git -C "$repository" bundle create "$output_directory/all-refs.bundle" --all
+tar -czf "$output_directory/local-continuity.tar.gz" -C "$repository" -T "$include_file"
+cp "$recovery_file" "$output_directory/RECOVERY.md"
+cp "$include_file" "$output_directory/INCLUDE.txt"
+
+printf '%s\n' \
+  "schema=ai4x-project-work-continuity-bootstrap-v1" \
+  "issue=181" \
+  "slot=$slot" \
+  "created_at=$created_at" \
+  "repository=$origin_url" \
+  "branch=$branch" \
+  "head=$head_revision" \
+  "upstream=$upstream" \
+  "upstream_head=$upstream_revision" \
+  "origin_trunk=$origin_trunk" \
+  "tracked_worktree=clean" \
+  > "$output_directory/MANIFEST.txt"
+
+(
+  cd "$output_directory"
+  shasum -a 256 all-refs.bundle local-continuity.tar.gz RECOVERY.md INCLUDE.txt MANIFEST.txt > SHA256SUMS
+)
+
+"$verifier" "$output_directory"

--- a/util/work-continuity/tst/verify-work-continuity.sh
+++ b/util/work-continuity/tst/verify-work-continuity.sh
@@ -59,10 +59,37 @@ upstream_revision=$head_revision
 origin_trunk=$head_revision
 git -C "$fixture_repository" update-ref refs/remotes/origin/trunk "$origin_trunk"
 
+fixture_include="$scratch_root/fixture-INCLUDE.txt"
+printf '%s\n' \
+  '.ai4x/local/session-scratch/102/epic-review.md' \
+  '.ai4x/local/session-scratch/103/command-surface-review.md' \
+  '.ai4x/local/session-scratch/103/curation-functional-contract.md' \
+  '.ai4x/local/session-scratch/103/epic-body.md' \
+  '.ai4x/local/session-scratch/103/first-story-body.md' \
+  '.ai4x/local/session-scratch/103/reference/ai4x-logo/ai4X Logo.jpg' \
+  '.ai4x/local/session-scratch/103/reference/complete-sfe-run-interaction.md' \
+  '.ai4x/local/session-scratch/103/reference/complete-sfe-run-interaction.png' \
+  '.ai4x/local/session-scratch/103/reference/complete-sfe-run-interaction.tex' \
+  '.ai4x/local/session-scratch/103/refinement-comment.md' \
+  '.ai4x/local/session-scratch/180/work-continuity-portfolio-and-project-instance.md' \
+  '.ai4x/local/session-scratch/CURRENT-HANDOFF.md' \
+  '.ai4x/local/session-scratch/NEXT-SESSION-PROMPT.md' \
+  > "$fixture_include"
+
+if ! cmp -s "$include_file" "$fixture_include"; then
+  echo 'test fixture inclusion policy differs from tracked policy' >&2
+  exit 1
+fi
+
+while IFS= read -r included_path; do
+  mkdir -p "$(dirname -- "$fixture_repository/$included_path")"
+  printf 'fixture: %s\n' "$included_path" > "$fixture_repository/$included_path"
+done < "$fixture_include"
+
 git -C "$fixture_repository" bundle create "$valid/all-refs.bundle" --all
-tar -czf "$valid/local-continuity.tar.gz" -C "$repository" -T "$include_file"
+tar -czf "$valid/local-continuity.tar.gz" -C "$fixture_repository" -T "$fixture_include"
 cp "$repository/.ai4x/operations/work-continuity/RECOVERY.md" "$valid/RECOVERY.md"
-cp "$include_file" "$valid/INCLUDE.txt"
+cp "$fixture_include" "$valid/INCLUDE.txt"
 printf '%s\n' \
   'schema=ai4x-project-work-continuity-bootstrap-v1' \
   'issue=181' \
@@ -117,7 +144,7 @@ tar -xzf "$valid/local-continuity.tar.gz" -C "$archive_root"
 symlink_member="$archive_root/.ai4x/local/session-scratch/102/epic-review.md"
 rm "$symlink_member"
 ln -s ../CURRENT-HANDOFF.md "$symlink_member"
-tar -czf "$symlink_archive/local-continuity.tar.gz" -C "$archive_root" -T "$include_file"
+tar -czf "$symlink_archive/local-continuity.tar.gz" -C "$archive_root" -T "$fixture_include"
 write_checksums "$symlink_archive"
 expect_failure symlink-archive "$verifier" "$symlink_archive"
 
@@ -127,6 +154,13 @@ printf 'safe\n' > "$source_root/.ai4x/local/real/file"
 ln -s real "$source_root/.ai4x/local/link"
 printf '.ai4x/local/link/file\n' > "$scratch_root/symlink-parent-include.txt"
 expect_failure symlink-parent validate_local_sources "$source_root" "$scratch_root/symlink-parent-include.txt"
+
+root_symlink_source="$scratch_root/root-symlink-source"
+mkdir -p "$root_symlink_source/.ai4x" "$root_symlink_source/real-local/real"
+printf 'unsafe\n' > "$root_symlink_source/real-local/real/file"
+ln -s ../../real-local "$root_symlink_source/.ai4x/local"
+printf '.ai4x/local/real/file\n' > "$scratch_root/symlink-root-include.txt"
+expect_failure symlink-root validate_local_sources "$root_symlink_source" "$scratch_root/symlink-root-include.txt"
 expect_failure credential-url require_safe_repository_url 'https://token@github.com/normenmueller/ai4X.git'
 
 echo '[ai4x] work-continuity-test: passed'

--- a/util/work-continuity/tst/verify-work-continuity.sh
+++ b/util/work-continuity/tst/verify-work-continuity.sh
@@ -1,0 +1,122 @@
+#!/bin/sh
+set -eu
+
+script_directory=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+repository=$(CDPATH= cd -- "$script_directory/../../.." && pwd)
+verifier="$repository/util/work-continuity/verify-checkpoint.sh"
+common="$repository/util/work-continuity/common.sh"
+include_file="$repository/.ai4x/operations/work-continuity/INCLUDE.txt"
+scratch_parent="$repository/.ai4x/local/verification"
+mkdir -p "$scratch_parent"
+scratch_root=$(mktemp -d "$scratch_parent/work-continuity.XXXXXX")
+
+cleanup() {
+  case "$scratch_root" in
+    "$scratch_parent"/work-continuity.*) rm -rf "$scratch_root" ;;
+    *) echo "refusing unsafe test cleanup: $scratch_root" >&2 ;;
+  esac
+}
+trap cleanup EXIT HUP INT TERM
+
+. "$common"
+
+write_checksums() (
+  checkpoint=$1
+  cd "$checkpoint"
+  shasum -a 256 all-refs.bundle local-continuity.tar.gz RECOVERY.md INCLUDE.txt MANIFEST.txt > SHA256SUMS
+)
+
+copy_checkpoint() {
+  source_checkpoint=$1
+  target_checkpoint=$2
+  cp -R "$source_checkpoint" "$target_checkpoint"
+}
+
+expect_failure() {
+  name=$1
+  shift
+
+  if "$@" > "$scratch_root/$name.out" 2>&1; then
+    echo "expected failure was accepted: $name" >&2
+    exit 1
+  fi
+}
+
+valid="$scratch_root/valid"
+mkdir -p "$valid"
+branch=$(git -C "$repository" branch --show-current)
+head_revision=$(git -C "$repository" rev-parse HEAD)
+upstream_revision=$(git -C "$repository" rev-parse '@{upstream}')
+origin_trunk=$(git -C "$repository" rev-parse refs/remotes/origin/trunk)
+
+git -C "$repository" bundle create "$valid/all-refs.bundle" --all
+tar -czf "$valid/local-continuity.tar.gz" -C "$repository" -T "$include_file"
+cp "$repository/.ai4x/operations/work-continuity/RECOVERY.md" "$valid/RECOVERY.md"
+cp "$include_file" "$valid/INCLUDE.txt"
+printf '%s\n' \
+  'schema=ai4x-project-work-continuity-bootstrap-v1' \
+  'issue=181' \
+  'slot=slot-a' \
+  'created_at=2026-08-26T00:00:00Z' \
+  'repository=git@github.com:normenmueller/ai4X.git' \
+  "branch=$branch" \
+  "head=$head_revision" \
+  "upstream=origin/$branch" \
+  "upstream_head=$upstream_revision" \
+  "origin_trunk=$origin_trunk" \
+  'tracked_worktree=clean' \
+  > "$valid/MANIFEST.txt"
+write_checksums "$valid"
+"$verifier" "$valid" > /dev/null
+
+truncated_checksums="$scratch_root/truncated-checksums"
+copy_checkpoint "$valid" "$truncated_checksums"
+sed -n '1,4p' "$valid/SHA256SUMS" > "$truncated_checksums/SHA256SUMS"
+expect_failure truncated-checksums "$verifier" "$truncated_checksums"
+
+external_checksum="$scratch_root/external-checksum"
+copy_checkpoint "$valid" "$external_checksum"
+printf '%064d  ../outside\n' 0 >> "$external_checksum/SHA256SUMS"
+expect_failure external-checksum "$verifier" "$external_checksum"
+
+wrong_manifest="$scratch_root/wrong-manifest"
+copy_checkpoint "$valid" "$wrong_manifest"
+sed 's/^head=.*/head=0000000000000000000000000000000000000000/' \
+  "$valid/MANIFEST.txt" > "$wrong_manifest/MANIFEST.txt"
+write_checksums "$wrong_manifest"
+expect_failure wrong-manifest "$verifier" "$wrong_manifest"
+
+traversal="$scratch_root/traversal"
+copy_checkpoint "$valid" "$traversal"
+sed '1s|.*|.ai4x/local/../escape|' "$valid/INCLUDE.txt" > "$traversal/INCLUDE.txt"
+write_checksums "$traversal"
+expect_failure path-traversal "$verifier" "$traversal"
+
+duplicate="$scratch_root/duplicate"
+copy_checkpoint "$valid" "$duplicate"
+first_entry=$(sed -n '1p' "$valid/INCLUDE.txt")
+printf '%s\n' "$first_entry" >> "$duplicate/INCLUDE.txt"
+write_checksums "$duplicate"
+expect_failure duplicate-include "$verifier" "$duplicate"
+
+symlink_archive="$scratch_root/symlink-archive"
+copy_checkpoint "$valid" "$symlink_archive"
+archive_root="$scratch_root/archive-root"
+mkdir -p "$archive_root"
+tar -xzf "$valid/local-continuity.tar.gz" -C "$archive_root"
+symlink_member="$archive_root/.ai4x/local/session-scratch/102/epic-review.md"
+rm "$symlink_member"
+ln -s ../CURRENT-HANDOFF.md "$symlink_member"
+tar -czf "$symlink_archive/local-continuity.tar.gz" -C "$archive_root" -T "$include_file"
+write_checksums "$symlink_archive"
+expect_failure symlink-archive "$verifier" "$symlink_archive"
+
+source_root="$scratch_root/source-root"
+mkdir -p "$source_root/.ai4x/local/real"
+printf 'safe\n' > "$source_root/.ai4x/local/real/file"
+ln -s real "$source_root/.ai4x/local/link"
+printf '.ai4x/local/link/file\n' > "$scratch_root/symlink-parent-include.txt"
+expect_failure symlink-parent validate_local_sources "$source_root" "$scratch_root/symlink-parent-include.txt"
+expect_failure credential-url require_safe_repository_url 'https://token@github.com/normenmueller/ai4X.git'
+
+echo '[ai4x] work-continuity-test: passed'

--- a/util/work-continuity/tst/verify-work-continuity.sh
+++ b/util/work-continuity/tst/verify-work-continuity.sh
@@ -44,12 +44,22 @@ expect_failure() {
 
 valid="$scratch_root/valid"
 mkdir -p "$valid"
-branch=$(git -C "$repository" branch --show-current)
-head_revision=$(git -C "$repository" rev-parse HEAD)
-upstream_revision=$(git -C "$repository" rev-parse '@{upstream}')
-origin_trunk=$(git -C "$repository" rev-parse refs/remotes/origin/trunk)
+fixture_repository="$scratch_root/git-source"
+mkdir -p "$fixture_repository"
+git -C "$fixture_repository" init -q
+git -C "$fixture_repository" config user.name 'ai4X Work Continuity Test'
+git -C "$fixture_repository" config user.email 'work-continuity-test@invalid.example'
+printf 'fixture\n' > "$fixture_repository/content"
+git -C "$fixture_repository" add content
+git -C "$fixture_repository" commit -q -m fixture
+branch=fixture-work-continuity
+git -C "$fixture_repository" branch -m "$branch"
+head_revision=$(git -C "$fixture_repository" rev-parse HEAD)
+upstream_revision=$head_revision
+origin_trunk=$head_revision
+git -C "$fixture_repository" update-ref refs/remotes/origin/trunk "$origin_trunk"
 
-git -C "$repository" bundle create "$valid/all-refs.bundle" --all
+git -C "$fixture_repository" bundle create "$valid/all-refs.bundle" --all
 tar -czf "$valid/local-continuity.tar.gz" -C "$repository" -T "$include_file"
 cp "$repository/.ai4x/operations/work-continuity/RECOVERY.md" "$valid/RECOVERY.md"
 cp "$include_file" "$valid/INCLUDE.txt"

--- a/util/work-continuity/verify-checkpoint.sh
+++ b/util/work-continuity/verify-checkpoint.sh
@@ -1,0 +1,57 @@
+#!/bin/sh
+set -eu
+
+if [ "$#" -ne 1 ]; then
+  echo "usage: $0 CHECKPOINT_DIRECTORY" >&2
+  exit 64
+fi
+
+checkpoint_directory=$1
+script_directory=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+repository=$(CDPATH= cd -- "$script_directory/../.." && pwd)
+verification_root="$repository/.ai4x/local/work-continuity"
+
+for required_file in all-refs.bundle local-continuity.tar.gz RECOVERY.md INCLUDE.txt MANIFEST.txt SHA256SUMS; do
+  if [ ! -f "$checkpoint_directory/$required_file" ]; then
+    echo "missing checkpoint file: $required_file" >&2
+    exit 66
+  fi
+done
+
+mkdir -p "$verification_root"
+verification_directory=$(mktemp -d "$verification_root/verification.XXXXXX")
+
+cleanup() {
+  case "$verification_directory" in
+    "$verification_root"/verification.*) rm -rf "$verification_directory" ;;
+    *) echo "refusing unsafe verification cleanup: $verification_directory" >&2 ;;
+  esac
+}
+trap cleanup EXIT HUP INT TERM
+
+(
+  cd "$checkpoint_directory"
+  shasum -a 256 -c SHA256SUMS
+)
+
+git bundle verify "$checkpoint_directory/all-refs.bundle"
+tar -tzf "$checkpoint_directory/local-continuity.tar.gz" > "$verification_directory/archive.txt"
+sort "$checkpoint_directory/INCLUDE.txt" > "$verification_directory/include.txt"
+sort "$verification_directory/archive.txt" > "$verification_directory/archive-sorted.txt"
+
+if ! cmp -s "$verification_directory/include.txt" "$verification_directory/archive-sorted.txt"; then
+  echo "archive entries do not equal INCLUDE.txt" >&2
+  exit 65
+fi
+
+if ! grep -F -x 'schema=ai4x-project-work-continuity-bootstrap-v1' "$checkpoint_directory/MANIFEST.txt" > /dev/null; then
+  echo "unsupported checkpoint schema" >&2
+  exit 65
+fi
+
+if ! grep -F -x 'tracked_worktree=clean' "$checkpoint_directory/MANIFEST.txt" > /dev/null; then
+  echo "checkpoint was not created from a clean tracked worktree" >&2
+  exit 65
+fi
+
+echo "verified: $checkpoint_directory"

--- a/util/work-continuity/verify-checkpoint.sh
+++ b/util/work-continuity/verify-checkpoint.sh
@@ -10,6 +10,8 @@ checkpoint_directory=$1
 script_directory=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
 repository=$(CDPATH= cd -- "$script_directory/../.." && pwd)
 verification_root="$repository/.ai4x/local/work-continuity"
+tracked_include="$repository/.ai4x/operations/work-continuity/INCLUDE.txt"
+. "$script_directory/common.sh"
 
 for required_file in all-refs.bundle local-continuity.tar.gz RECOVERY.md INCLUDE.txt MANIFEST.txt SHA256SUMS; do
   if [ ! -f "$checkpoint_directory/$required_file" ]; then
@@ -29,28 +31,134 @@ cleanup() {
 }
 trap cleanup EXIT HUP INT TERM
 
+printf '%s\n' \
+  INCLUDE.txt \
+  MANIFEST.txt \
+  RECOVERY.md \
+  all-refs.bundle \
+  local-continuity.tar.gz \
+  > "$verification_directory/expected-checksum-files.txt"
+
+if grep -Eqv '^[0-9a-f]{64}  [A-Za-z0-9.-]+$' "$checkpoint_directory/SHA256SUMS"; then
+  echo "checksum manifest contains an invalid entry" >&2
+  exit 65
+fi
+
+awk '{ print $2 }' "$checkpoint_directory/SHA256SUMS" \
+  | LC_ALL=C sort > "$verification_directory/checksum-files.txt"
+
+if ! cmp -s "$verification_directory/expected-checksum-files.txt" "$verification_directory/checksum-files.txt"; then
+  echo "checksum manifest does not name the exact expected files" >&2
+  exit 65
+fi
+
 (
   cd "$checkpoint_directory"
   shasum -a 256 -c SHA256SUMS
 )
 
-git bundle verify "$checkpoint_directory/all-refs.bundle"
-tar -tzf "$checkpoint_directory/local-continuity.tar.gz" > "$verification_directory/archive.txt"
-sort "$checkpoint_directory/INCLUDE.txt" > "$verification_directory/include.txt"
-sort "$verification_directory/archive.txt" > "$verification_directory/archive-sorted.txt"
+printf '%s\n' \
+  branch \
+  created_at \
+  head \
+  issue \
+  origin_trunk \
+  repository \
+  schema \
+  slot \
+  tracked_worktree \
+  upstream \
+  upstream_head \
+  > "$verification_directory/expected-manifest-fields.txt"
 
-if ! cmp -s "$verification_directory/include.txt" "$verification_directory/archive-sorted.txt"; then
+awk -F= '{ print $1 }' "$checkpoint_directory/MANIFEST.txt" \
+  | LC_ALL=C sort > "$verification_directory/manifest-fields.txt"
+
+if ! cmp -s "$verification_directory/expected-manifest-fields.txt" "$verification_directory/manifest-fields.txt"; then
+  echo "manifest fields are incomplete, duplicated, or unexpected" >&2
+  exit 65
+fi
+
+manifest_value() {
+  awk -F= -v key="$1" '$1 == key { sub(/^[^=]*=/, ""); print }' "$checkpoint_directory/MANIFEST.txt"
+}
+
+schema=$(manifest_value schema)
+issue=$(manifest_value issue)
+slot=$(manifest_value slot)
+repository_url=$(manifest_value repository)
+branch=$(manifest_value branch)
+head_revision=$(manifest_value head)
+upstream=$(manifest_value upstream)
+upstream_revision=$(manifest_value upstream_head)
+origin_trunk=$(manifest_value origin_trunk)
+tracked_worktree=$(manifest_value tracked_worktree)
+created_at=$(manifest_value created_at)
+
+if [ "$schema" != ai4x-project-work-continuity-bootstrap-v1 ] \
+  || [ "$issue" != 181 ] \
+  || [ "$tracked_worktree" != clean ]; then
+  echo "manifest has an unsupported schema, issue, or worktree state" >&2
+  exit 65
+fi
+
+case "$slot" in
+  slot-a|slot-b|slot-c) ;;
+  *) echo "manifest has an invalid slot" >&2; exit 65 ;;
+esac
+
+if ! printf '%s\n' "$created_at" | grep -Eq '^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$'; then
+  echo "manifest has an invalid creation time" >&2
+  exit 65
+fi
+
+require_safe_repository_url "$repository_url"
+
+if ! git check-ref-format --branch "$branch" > /dev/null \
+  || [ "$upstream" != "origin/$branch" ]; then
+  echo "manifest has an invalid branch or upstream" >&2
+  exit 65
+fi
+
+for revision in "$head_revision" "$upstream_revision" "$origin_trunk"; do
+  if ! printf '%s\n' "$revision" | grep -Eq '^[0-9a-f]{40}$'; then
+    echo "manifest has an invalid Git revision" >&2
+    exit 65
+  fi
+done
+
+if [ "$head_revision" != "$upstream_revision" ]; then
+  echo "manifest head does not equal upstream head" >&2
+  exit 65
+fi
+
+git bundle verify "$checkpoint_directory/all-refs.bundle"
+bundle_branch=$(git bundle list-heads "$checkpoint_directory/all-refs.bundle" "refs/heads/$branch" | awk '{ print $1 }')
+bundle_trunk=$(git bundle list-heads "$checkpoint_directory/all-refs.bundle" refs/remotes/origin/trunk | awk '{ print $1 }')
+
+if [ "$bundle_branch" != "$head_revision" ] || [ "$bundle_trunk" != "$origin_trunk" ]; then
+  echo "bundle refs do not match the manifest" >&2
+  exit 65
+fi
+
+validate_include_syntax "$checkpoint_directory/INCLUDE.txt"
+
+if ! cmp -s "$tracked_include" "$checkpoint_directory/INCLUDE.txt"; then
+  echo "checkpoint inclusion manifest differs from tracked policy" >&2
+  exit 65
+fi
+
+tar -tzf "$checkpoint_directory/local-continuity.tar.gz" > "$verification_directory/archive.txt"
+LC_ALL=C sort "$verification_directory/archive.txt" > "$verification_directory/archive-sorted.txt"
+
+if ! cmp -s "$checkpoint_directory/INCLUDE.txt" "$verification_directory/archive-sorted.txt"; then
   echo "archive entries do not equal INCLUDE.txt" >&2
   exit 65
 fi
 
-if ! grep -F -x 'schema=ai4x-project-work-continuity-bootstrap-v1' "$checkpoint_directory/MANIFEST.txt" > /dev/null; then
-  echo "unsupported checkpoint schema" >&2
-  exit 65
-fi
-
-if ! grep -F -x 'tracked_worktree=clean' "$checkpoint_directory/MANIFEST.txt" > /dev/null; then
-  echo "checkpoint was not created from a clean tracked worktree" >&2
+tar -tvzf "$checkpoint_directory/local-continuity.tar.gz" > "$verification_directory/archive-verbose.txt"
+if ! awk 'substr($0, 1, 1) == "-" { next } { exit 1 }' "$verification_directory/archive-verbose.txt"; then
+  echo "archive contains a non-regular member" >&2
   exit 65
 fi
 


### PR DESCRIPTION
## Outcome

Make the concrete ai4X project instance reconstructable after a workstation
factory reset without prematurely implementing the reusable Work Continuity
Portfolio offering proposed in #180.

## What changed

- add agent-facing instance rules, an exact positive inclusion inventory, a
  recovery procedure, and a logical local binding boundary under `.ai4x/`;
- add provisional tracked checkpoint and fail-closed verification tooling under
  `util/work-continuity/`;
- add mutation tests for checksum, manifest, path, archive, symlink, and remote
  URL failures;
- record a redacted clean-clone restore proof and readiness receipt.

The external recovery target remains inert and non-authoritative. Concrete
provider paths remain ignored and machine-local. This PR does not implement or
pre-decide #180's Portfolio resources, Haskell domain, adapters, or public CLI.

## Verification

- `make verify`
- exact branch/upstream equality at `74990292b61e52a5a63d9f5a4d5ce237d5fadc4f`
- fresh GitHub clone, tracked verifier, exact local restore, and complete
  repository verification recorded in the tracked proof
- independent architecture re-review: all former high and medium findings
  resolved; no findings on final remote HEAD `a8a3b8f`

Closes #181
