### PR TITLE
Make ai4X Cold Starts self-discovering

### DIFF
--- a/.ai4x/BEHAVIOR.md
+++ b/.ai4x/BEHAVIOR.md
@@ -41,34 +41,30 @@ A Cold Start means ending the current Codex session and starting a fresh one
 without `resume` or `fork`. Complete all of the following before recommending it:
 
 1. Stabilize the current task and verify repository, GitHub, branch, and CI state.
-2. Perform a bounded cleanup pass over disposable ai4X state in `~/.codex`.
-   Remove only artifacts whose scope and disposability are proven and authorized;
-   preserve configuration, authentication, plugins, skills, rules, unrelated
-   sessions, and anything still needed for recovery or handoff.
-3. Clean obsolete workspace-local temporary material under `.ai4x/local/`, while
-   preserving the current handoff and next-session prompt. Use workspace-local
-   temporary paths for ai4X work; do not use the operating system `/tmp`.
-4. Integrate any changed tracked `.ai4x` authority, then update every relevant
-   handoff and `.ai4x/local/session-scratch/NEXT-SESSION-PROMPT.md`. Verify that
-   all referenced paths exist and that a fresh agent can execute the prompt
-   without prior conversation context.
-5. Confirm that no intended change, unresolved decision, or recovery fact exists
-   only in chat or disposable temporary state.
+2. Move every durable semantic or governance decision out of chat and local
+   scratch into its tracked owner or the owning GitHub Issue.
+3. Clean only workspace-local material proven obsolete and disposable. Preserve
+   unknown or unrelated state; never make host-wide cleanup a routine Cold Start
+   requirement.
+4. Update one concise `.ai4x/local/session-scratch/CURRENT-HANDOFF.md` when local
+   continuity is still useful. It is a non-authoritative snapshot and router,
+   not a copied prompt or semantic owner.
+5. Refresh the external recovery set only when necessary local continuity state
+   materially changed, then prove that no required fact exists only in chat or
+   disposable state.
 
-Use two separate assistant responses for the handoff:
+Report that the Cold Start is prepared, ask the Product Owner to end the session
+with `/delete`, open a fresh session in this repository without `resume` or
+`fork`, and send a normal continuation greeting such as `Hi Gertrud, weiter
+geht's!`. Do not ask the Product Owner to copy a transition prompt and do not
+start further work in the old session.
 
-1. Give a normal completion report with the explicit Cold Start recommendation,
-   the manual end-and-new-session-without-resume action, and confirmation that no
-   further work will start in the current session. Do not include the transition
-   prompt.
-2. After the Product Owner acknowledges, respond with only the self-contained
-   transition prompt suitable for `/copy`: no heading, code fence, preface, or
-   trailing commentary.
-
-The transition prompt identifies the repository root, requires the fresh agent
-to read `BEHAVIOR.md`, `CONTEXT.md`, and the current handoff, states the exact
-approved work and exclusions, starts with bounded read-only verification, and
-then authorizes immediate execution of the handoff's next action.
+A continuation greeting without a concrete task authorizes only the bounded
+read-only bootstrap in [operations/session-continuity.md](operations/session-continuity.md).
+It never grants branch switching, cleanup, publication, merge, lifecycle,
+destructive, or new-scope authority. Mutation may resume only after that
+procedure establishes one unambiguous existing work context whose live contract
+already grants the required effect.
 
 ## Delivery
 

--- a/.ai4x/CONTEXT.md
+++ b/.ai4x/CONTEXT.md
@@ -4,7 +4,13 @@ Start with [BEHAVIOR.md](BEHAVIOR.md). Then load only what the task needs:
 
 - [context/architecture.md](context/architecture.md) for structure and authority boundaries;
 - [context/domain-language.md](context/domain-language.md) for core terminology;
+- [operations/session-continuity.md](operations/session-continuity.md) when a
+  fresh session begins with only a continuation greeting;
 - [operations/work-continuity.md](operations/work-continuity.md) for factory-reset readiness and recovery;
+- [context/need-to-capability.md](context/need-to-capability.md) only for the
+  Need-to-Capability architecture and #103;
+- [context/curation.md](context/curation.md) only for the canonical Curation
+  algebra and type-state flow;
 - the owning GitHub Issue for requirements, status, and acceptance criteria;
 - the affected source, tests, and nearby documentation for implementation work.
 

--- a/.ai4x/bindings/work-continuity.md
+++ b/.ai4x/bindings/work-continuity.md
@@ -10,6 +10,10 @@ Record the active machine's target root as the only line in:
 .ai4x/local/work-continuity/target
 ```
 
+The operator must supply this root explicitly after a factory reset or host
+replacement. Agents must not search for, infer, or guess it. Until the binding
+exists and the target layout is verified, recovery is blocked.
+
 The target must provide this bounded layout:
 
 ```text
@@ -24,5 +28,7 @@ work-continuity/
 ```
 
 `CURRENT` contains one relative rolling-slot name such as `rolling/slot-a`.
+It selects only a recovery slot below the operator-supplied root. It does not
+select an Issue, authorize work, choose a branch policy, or own semantics.
 The target remains outside the active repository and must never be used as a
 working directory, tracked authority, or destination for build output.

--- a/.ai4x/context/architecture.md
+++ b/.ai4x/context/architecture.md
@@ -5,6 +5,20 @@
 tooling. `.github/`, `.codex/`, and root `AGENTS.md` are thin host facades; they
 must not become independent semantic authorities.
 
+Authority is split by fact kind:
+
+- current explicit Product Owner instructions own current mutation authority;
+- tracked `.ai4x/` and tracked architecture own durable behavior and semantics;
+- GitHub Issues, the project board, and Pull Requests own mutable work and
+  lifecycle state;
+- the observed worktree is state to preserve, never an instruction to discard;
+- `.ai4x/local/` contains working and continuity material only; it is never
+  semantic or governance authority;
+- external recovery material is inert continuity fallback, never work authority.
+
+On disagreement, use the owner for that fact kind. Preserve local changes and
+fail closed to the Product Owner when authority or the owning work is ambiguous.
+
 The complete planned directory skeleton is intentionally tracked as a memory aid.
 Its `.gitkeep` markers are location commitments, not permission to invent empty
 contracts or speculative implementations. Materialize content through small,
@@ -30,8 +44,18 @@ source roots: a future Light edition must be expressed as a justified bundle or
 skeleton, while policy belongs to Corpus Governance or Assurance packs.
 
 Authoritative project declarations are intended to use Dhall; closed product
-semantics are intended to use Haskell. Prototype and historical evidence remain
-outside `trunk` until a product slice deliberately adopts a proven result.
+semantics are intended to use Haskell. Describe this formal boundary as
+**strongly and statically typed**, not as a "strict type system": Dhall provides
+total, typed declarative inputs, while Haskell owns closed domain types,
+invariants, and deterministic transformations; Haskell evaluation itself is
+non-strict. Prototype and historical evidence remain outside `trunk` until a
+product slice deliberately adopts a proven result.
+
+The Need-to-Capability ownership flow is tracked in
+[need-to-capability.md](need-to-capability.md). Its normative Curation algebra
+and invariants have exactly one owner: [curation.md](curation.md). Diagrams,
+vocabulary, examples, and local drafts are projections or evidence, not
+competing type authorities.
 
 `.ai4x/generated/` and `.ai4x/local/` are declared exceptions to the tracked
 skeleton. They are created only on demand and remain ignored. Their intended

--- a/.ai4x/context/curation.md
+++ b/.ai4x/context/curation.md
@@ -1,0 +1,168 @@
+# Curation Context
+
+This file is the single normative owner of the current Curation semantic
+algebra for the Need-to-Capability architecture. It fixes essential states,
+ownership, transitions, and invariants without authorizing implementation or
+prematurely choosing a concrete Haskell encoding.
+
+## Reading convention
+
+- `A × B` means both values are required.
+- `A | B` means exactly one outcome.
+- `Either E A` means deterministic failure or success.
+- `<Phase>` denotes a distinct closed domain state.
+- Phase-changing constructors are opaque and owned by their transition.
+- Cognitive and human contracts use function notation without claiming
+  deterministic library execution.
+
+## Canonical values
+
+```text
+CandidateDecisions<Complete>
+├─ source CapabilityCandidates<Identified>
+├─ exactly one disposition for every source Candidate
+├─ rationale reference for every disposition
+└─ every required Cognitive Job covered or recorded as an explicit gap
+
+CurationRationale<Authored>
+├─ authoritative selection and non-selection rationale entries
+├─ supporting source references
+└─ explicit uncertainty
+
+CurationProposal<Draft>
+├─ source ProjectIntent<Validated>
+├─ source CapabilityCandidates<Identified>
+├─ CandidateDecisions<Complete>
+├─ AgenticConstellation<Draft>
+└─ CurationRationale<Authored>
+
+AgenticConstellation<Draft>
+├─ selected cognitive Capabilities
+├─ Cognitive Agent Team
+└─ Operating Model
+   ├─ Collaboration Model
+   ├─ Work Management Model
+   └─ Governance Model
+
+CurationTrace
+├─ exact CurationProposal<Draft> binding
+├─ exact checked CapabilityCorpus<Released> binding
+├─ released-Corpus membership and exact Capability references
+├─ complete disposition and rationale-link evidence
+├─ closed dependency and conflict graph
+└─ canonical ordering
+
+VerifiedCuration
+├─ CurationProposal<Draft>
+└─ CurationTrace
+
+CurationProposal<Reviewable>
+├─ VerifiedCuration
+└─ ReviewExplanation<Authored>
+
+AcceptedCuration
+├─ accepted CurationProposal<Reviewable>
+├─ unchanged AgenticConstellation<Curated>
+└─ HumanAcceptance<Recorded>
+```
+
+`ReviewExplanation<Authored>` presents rationale, evidence, gaps, uncertainty,
+and review questions. It may clarify existing semantics but cannot change them.
+
+## Functional contracts and ownership
+
+```text
+AI Host + ai4X Cognition
+curateAgenticConstellation :
+  ProjectIntent<Validated>
+  × CapabilityCandidates<Identified>
+  -> Drafted CurationProposal<Draft>
+   | CurationBlocked (NonEmpty CurationGap)
+
+ai4X Library / CLI
+verifyCuration :
+  CapabilityCorpus<Released>
+  × CurationProposal<Draft>
+  -> Either (NonEmpty CurationDefect) VerifiedCuration
+
+AI Host + ai4X Cognition
+explainCuration :
+  VerifiedCuration
+  -> CurationProposal<Reviewable>
+
+Human Authority
+decideOnCurationProposal :
+  CurationProposal<Reviewable>
+  -> Accept AcceptedCuration
+   | RequestRevision CurationRevisionRequest
+   | Reject CurationRejection
+
+ai4X Library / CLI
+persistCuration :
+  AcceptedCuration
+  -> Either (NonEmpty PersistenceDefect)
+            ProjectConfiguration<Persisted>
+```
+
+## Non-negotiable invariants
+
+1. Every source Candidate is exactly once `Selected` or `NotSelected`.
+2. Every disposition refers to one entry in the authoritative authored
+   rationale.
+3. Selected decisions correspond exactly to the selected cognitive
+   Capabilities in the Draft Constellation.
+4. Every required Cognitive Job is covered or visible as an explicit gap.
+5. Rationale owns cognitive judgment; `CurationTrace` owns deterministic
+   verification facts. Neither duplicates the other.
+6. Only `verifyCuration` constructs opaque `VerifiedCuration`, binding the exact
+   Draft, Trace, and checked released Corpus.
+7. `ReviewExplanation<Authored>` cannot silently change domain semantics. A
+   material change creates a revised Draft and requires renewed verification.
+8. Human acceptance binds the exact Reviewable Proposal.
+9. `Draft -> Curated` changes phase only; the Constellation payload is unchanged.
+10. `AcceptedCuration` is no longer a Proposal.
+11. Persistence preserves the accepted semantic and evidence boundary but does
+    not activate the Constellation.
+
+## Essential diagram projection
+
+The lean architecture diagram shows only these trees and success states:
+
+```text
+CurationProposal<Draft>
+├─ AgenticConstellation<Draft>
+└─ CurationRationale<Authored>
+
+VerifiedCuration
+├─ CurationProposal<Draft>
+└─ CurationTrace
+
+CurationProposal<Reviewable>
+├─ VerifiedCuration
+└─ ReviewExplanation<Authored>
+
+AcceptedCuration
+└─ AgenticConstellation<Curated>
+```
+
+```text
+CurationProposal<Draft>
+-> VerifiedCuration
+-> CurationProposal<Reviewable>
+-> AcceptedCuration
+-> ProjectConfiguration<Persisted>
+```
+
+## Deliberately deferred
+
+- concrete GADT, phantom-type, type-family, newtype, or module encoding;
+- identity, revision, reference, and digest representation;
+- Dhall declarations, codecs, and canonical serialization;
+- persistence schema and embedded-versus-referenced evidence;
+- internal reason, source, gap, uncertainty, and defect structures;
+- whether selected Capabilities must be non-empty;
+- whether `NotSelected` later separates rejected, deferred, or other outcomes;
+- Portfolio versus project-local origin of Team and Operating Model values.
+
+Any later implementation may choose among these representations only while
+preserving the invariants and constructor ownership above.

--- a/.ai4x/context/domain-language.md
+++ b/.ai4x/context/domain-language.md
@@ -1,8 +1,46 @@
 # Domain Language
 
+- **Agentic Cognition Engineering (ACE):** the discipline of turning human
+  intent into fit-for-purpose Agentic Constellations while keeping semantic
+  judgment cognitive and formal invariants, evidence, and projections
+  deterministic.
 - **Need:** the outcome or problem that motivates work.
 - **Capability:** reusable knowledge or behavior that may satisfy part of a Need.
+- **Capability Candidate:** an existing Capability from a released Corpus that
+  Scouting has identified as potentially fit for the validated Project Intent;
+  it is a reasoned proposal for Curation, not yet a selection.
+- **Candidate Decisions:** the complete Curation disposition of one identified
+  Candidate set. Every Candidate is selected or not selected exactly once,
+  refers to one authoritative rationale entry, and contributes to explicit
+  Cognitive Job coverage or a recorded gap.
 - **Agent:** a reusable composition of selected Capabilities.
+- **Cognitive Agent Team:** a team composed only of AI Agents. Humans may
+  participate in the surrounding collaboration but are not members of the
+  Cognitive Agent Team.
+- **Portfolio:** the governed reusable solution space available for curation. It
+  may include cognitive Capabilities; Collaboration, Work Management, and
+  Governance Models; Assurance Packs and deterministic controls; operational
+  tools; and integrations or adapters. Portfolio membership does not imply
+  project fitness, selection, composition, or activation.
+- **Agentic Constellation:** a coherent composition of selected Capabilities,
+  a Cognitive Agent Team, and an Operating Model comprising Collaboration, Work
+  Management, and Governance Models; it is curated for a concrete Need from
+  the Portfolio and remains inert until explicitly activated.
+- **Operating Model:** the Collaboration, Work Management, and Governance
+  Models within an Agentic Constellation; not a synonym for ai4X or for the
+  whole Constellation.
+- **Curation Proposal:** a phase-indexed package. In `<Draft>`, it binds the
+  validated Project Intent and identified Capability Candidates to complete
+  Candidate decisions, an `AgenticConstellation<Draft>`, and authored
+  rationale. In `<Reviewable>`, it contains the exact `VerifiedCuration` and a
+  cognitive review explanation; the proposal itself is not approval.
+- **Verified Curation:** an opaque deterministic result binding the exact
+  `CurationProposal<Draft>` to its `CurationTrace` and the released Capability
+  Corpus used for verification. It cannot supply semantic fitness or human
+  authority.
+- **Accepted Curation:** the exact `CurationProposal<Reviewable>`, its unchanged
+  Constellation phase-promoted to `AgenticConstellation<Curated>`, and recorded
+  human acceptance. It is no longer a proposal.
 - **Participant:** an Agent or human acting in a concrete collaboration.
 - **Assignment:** bounded work with explicit context, ownership, and authority.
 - **Project Memory:** the canonical, progressively loadable project context under `.ai4x/`.

--- a/.ai4x/context/need-to-capability.md
+++ b/.ai4x/context/need-to-capability.md
@@ -1,0 +1,125 @@
+# Need-to-Capability Context
+
+This file owns the accepted functional architecture behind the ai4X
+Need-to-Capability journey. It is a design target, not implementation authority.
+The owning Issue and live project state govern when any slice may be built.
+
+## Product identity
+
+ai4X is a human-led Need-to-Capability system for **Agentic Cognition
+Engineering (ACE)**. It turns human intent into fit-for-purpose Agentic
+Constellations—coherently curated and explicitly activated under human
+authority.
+
+```text
+ai4X Portfolio
+  -> governed reusable solution space
+
+Need-to-Capability journey
+  -> AgenticConstellation<Curated>
+       selected cognitive Capabilities
+       + Cognitive Agent Team
+       + Operating Model
+          Collaboration Model
+          Work Management Model
+          Governance Model
+  -> explicit activation under human authority
+```
+
+The Portfolio may contain cognitive Capabilities, deterministic Governance
+controls, Collaboration and Work Management Models, operational tools,
+Assurance Packs, integrations, and adapters. Portfolio membership does not
+imply project fitness, selection, composition, or activation.
+
+## Formal boundary
+
+Describe the system as **strongly and statically typed**, never as a strict type
+system. Dhall supplies total, typed declarative inputs. Haskell owns closed
+domain values, invariants, and deterministic transformations; its evaluation is
+non-strict. AI cognition authors meaning and explanations, while humans own
+confirmation and approval.
+
+```text
+Dhall declarations
+  -> closed Haskell values
+  -> deterministic evidence and projections
+```
+
+Deterministic success proves only closed values and formal invariants. It never
+manufactures semantic fitness, human confirmation, or approval.
+
+## Command architecture
+
+```text
+ai4x project adopt|create
+  -> ai4x scout
+       WHY + WHAT
+       ProjectIntent<Validated> + required Cognitive Jobs
+       need-fit Capability candidates; no selection or composition
+  -> ai4x curate
+       WHO + HOW
+       complete candidate decisions + authored rationale
+       selected cognitive Capabilities + Cognitive Agent Team
+       Collaboration + Work Management + Governance Models
+       explicit human acceptance
+       atomic ProjectConfiguration<Persisted> under <project>/.ai4x
+  -> ai4x spawn plan|apply
+       WHERE + HOST
+       explicit projection; no implicit autonomous execution
+```
+
+There is no public `ai4x declarations publish` ritual. Acceptance and
+persistence remain explicit typed boundaries within `ai4x curate`.
+
+Cross-cutting surfaces remain distinct:
+
+- `ai4x doctor` is read-only coherence diagnosis, never semantic approval or
+  Assurance;
+- `ai4x assurance run` executes explicitly bound Assurance Packs and emits
+  typed Receipts;
+- `ai4x memory prompt` emits the ai4X Light Prompt without project mutation;
+- `ai4x work ...` remains reserved for live work operations only if their owner
+  later proves ai4X authority.
+
+The CLI is a thin adapter. AI hosts author cognitive judgments, humans exercise
+authority, and deterministic libraries validate and project closed values.
+
+## Ownership flow
+
+- Human Authority confirms the Need, reviews Curation, accepts or requests
+  focused revision, and authorizes activation.
+- AI Host + ai4X Cognition elicits WHY and WHAT, authors Project Intent, scouts
+  Candidates, curates the Draft Constellation and rationale, and explains the
+  verified Proposal.
+- ai4X Library / CLI validates closed Intent values, verifies Curation, persists
+  accepted project configuration, and projects explicit activation plans.
+- Versioned Artifacts own exact phase-indexed values and deterministic evidence.
+
+The canonical Curation states and functions are owned only by
+[curation.md](curation.md).
+
+## Diagram projection rules
+
+- Read and review the journey from top to bottom, one bounded point at a time.
+- At each station check semantic correctness, execution ownership, canonical
+  type/state, arrow direction and label, and visual calm.
+- Preserve four ownership lanes: Human Authority; AI Host + ai4X Cognition;
+  ai4X Library / CLI; Versioned Artifacts.
+- Use cream for human decisions and one restrained Lavender family for ai4X
+  surfaces and lifecycle phases.
+- Distinguish activities, human decisions, semantic states, and versioned
+  artifacts by restrained box shape rather than decorative complexity.
+- Use `Family<Phase>` in code font for canonical values. Arrow labels carry
+  either one canonical value or one short action/outcome; dashed arrows mean
+  correction or revision.
+- Keep box typography hierarchical and lean: optional technical header, semantic
+  title, a few muted detail lines, and only an essential projected type tree.
+- Prefer balanced manual line breaks and remove prose before shrinking type.
+- Use horizontal `ai4X SCOUTING`, `ai4X CURATION`, and `ai4X SPAWNING` phase
+  bands while the vertical lanes retain execution ownership.
+- Preserve the accepted layout and spacing; render and inspect every approved
+  point, but commit coherent groups rather than individual micro-edits.
+
+The tracked diagram source, when present on the owning #103 branch, is the lean
+visual projection of these owners. It must not become a second semantic type
+authority.

--- a/.ai4x/operations/session-continuity.md
+++ b/.ai4x/operations/session-continuity.md
@@ -1,0 +1,116 @@
+# ai4X Session Continuity
+
+This is the canonical Cold Start discovery procedure for an intact workspace.
+It resumes existing work; it does not reconstruct lost work. Factory-reset and
+workspace-loss recovery belong to [work-continuity.md](work-continuity.md).
+
+## Continuation signal
+
+A fresh-session greeting with continuation intent and no concrete task, for
+example `Hi Gertrud, weiter geht's!`, authorizes only this read-only bootstrap.
+It is not mutation, publication, merge, lifecycle, cleanup, recovery-rotation,
+or new-scope authority.
+
+## Discovery algorithm
+
+1. Resolve the repository root with Git. Do not depend on a remembered absolute
+   path.
+2. Read the root agent facade, `.ai4x/BEHAVIOR.md`, and `.ai4x/CONTEXT.md`.
+3. If present, read `.ai4x/local/session-scratch/CURRENT-HANDOFF.md`. Treat it
+   only as an observed snapshot and routing hint. Reject an unknown schema or
+   duplicate required fields.
+4. Observe, without mutation, the current branch, `HEAD`, configured upstream,
+   tracked and untracked worktree state, and relevant local refs.
+5. Read live GitHub state for the handoff's owning Issue, project item,
+   relationships, matching Pull Request, remote branch, and required checks.
+6. Resolve every observation against its owning authority:
+
+   ```text
+   explicit current Product Owner instruction -> mutation authority
+   tracked Project Memory and architecture     -> behavior and semantics
+   live GitHub Issue / Project / PR             -> work and lifecycle state
+   observed worktree                            -> preserve local state
+   local handoff                                -> snapshot and routing only
+   external recovery target                     -> inert fallback only
+   ```
+
+7. Load only the owning Issue and its task-relevant context, source, tests, and
+   documentation.
+8. Produce exactly one routing result:
+
+   - `Resume`: one owning work item and next safe action are unambiguous. After
+     bootstrap, mutations may continue only when the live work contract already
+     grants that exact effect.
+   - `Await Product Owner`: the work context is clear but the next material
+     decision or authority is not.
+   - `Stop on drift`: observations conflict with their owners or local work
+     could be endangered. Preserve state, report the conflict, and do not
+     mutate.
+
+The bootstrap itself never switches branches, discards or cleans local state,
+publishes, merges, closes, changes project status, rotates recovery, or executes
+a mutation merely because the handoff suggests it.
+
+## Fail-closed cases
+
+Use `Await Product Owner` or `Stop on drift`, as appropriate, when any of these
+conditions prevents one safe route:
+
+- the handoff is missing, malformed, uses an unknown schema, or names multiple
+  owning Issues;
+- the owning Issue is closed, absent from the expected project, or conflicts
+  with its recorded board state;
+- branch, `HEAD`, upstream, remote branch, Pull Request, or required-check state
+  disagrees with the handoff or live work contract;
+- the worktree contains tracked or untracked changes whose ownership is not
+  proven;
+- more than one open work item plausibly owns the checkout;
+- GitHub is unavailable and current mutable work state is needed to choose or
+  authorize the next action;
+- an accepted semantic or governance decision exists only in chat, local
+  scratch, a handoff, evidence, or recovery material;
+- the suggested continuation requires branch switching, cleanup, publication,
+  merge, lifecycle mutation, destructive action, or new scope without exact
+  authority;
+- a local reference required by the route is missing;
+- external `CURRENT` or a restored handoff is older than tracked or live state.
+
+Never repair these cases by guessing. Preserve the workspace and ask one
+focused question only when read-only evidence cannot resolve the ambiguity.
+
+## Handoff contract
+
+`CURRENT-HANDOFF.md` is optional local continuity with this exact top-level
+shape:
+
+```text
+# ai4X Session Handoff
+Schema: ai4x-session-handoff-v1
+Observed: ISO-8601 timestamp
+Repository: owner/name
+Owning Issue: #number
+Expected Branch: branch
+
+## Route
+## Immediate next action
+## Authority boundaries
+## Observed snapshot
+## Necessary local-only continuity
+## Open decisions
+```
+
+The handoff contains concise pointers and observations only. Snapshot values
+must be re-read from Git and GitHub before mutation. Stable architecture,
+terminology, type contracts, figure grammar, command design, historical reports,
+and restore proofs belong to tracked owners or GitHub, never to the handoff.
+
+## Missing handoff fallback
+
+If no usable handoff exists, inspect the current branch, matching open Pull
+Request, and live active project items. Resume only when exactly one owning
+Issue and safe action are unambiguous from tracked and live authority. Otherwise
+await the Product Owner.
+
+Use external recovery only when the workspace or necessary local-only state is
+actually missing. Recovered handoffs remain snapshots and are resolved against
+the fresh tracked checkout and live GitHub state before use.

--- a/.ai4x/operations/work-continuity.md
+++ b/.ai4x/operations/work-continuity.md
@@ -25,6 +25,11 @@ recovery target contains only inert fallback material for explicitly selected
 local continuity state and additional local Git history. It is never an active
 workspace or a competing project authority.
 
+Normal `/delete` and fresh-session continuation use the intact workspace and
+[session-continuity.md](session-continuity.md). They do not read or rotate the
+external recovery target. Work Continuity is used only when tracked or necessary
+local state must be reconstructed.
+
 ## Project-instance boundary
 
 ```text

--- a/.ai4x/operations/work-continuity/INCLUDE.txt
+++ b/.ai4x/operations/work-continuity/INCLUDE.txt
@@ -1,6 +1,4 @@
 .ai4x/local/session-scratch/102/epic-review.md
-.ai4x/local/session-scratch/103/command-surface-review.md
-.ai4x/local/session-scratch/103/curation-functional-contract.md
 .ai4x/local/session-scratch/103/epic-body.md
 .ai4x/local/session-scratch/103/first-story-body.md
 .ai4x/local/session-scratch/103/reference/ai4x-logo/ai4X Logo.jpg
@@ -10,4 +8,3 @@
 .ai4x/local/session-scratch/103/refinement-comment.md
 .ai4x/local/session-scratch/180/work-continuity-portfolio-and-project-instance.md
 .ai4x/local/session-scratch/CURRENT-HANDOFF.md
-.ai4x/local/session-scratch/NEXT-SESSION-PROMPT.md

--- a/.ai4x/operations/work-continuity/RECOVERY.md
+++ b/.ai4x/operations/work-continuity/RECOVERY.md
@@ -1,5 +1,17 @@
 # ai4X Work-continuity Recovery
 
+## Operator-supplied recovery root
+
+Before reading recovery metadata, the human operator must supply the concrete
+recovery-target root for this machine. Do not search the filesystem, infer a
+cloud provider, reuse an absolute path from evidence, or guess a location.
+
+Recreate the machine-local binding in
+`.ai4x/local/work-continuity/target` exactly as described by
+`.ai4x/bindings/work-continuity.md`. Only then read `CURRENT` below that root.
+`CURRENT` selects one relative verified slot; it never identifies the owning
+Issue, branch policy, next action, or semantic authority.
+
 ## Normal reconstruction
 
 Read `MANIFEST.txt` from the slot named by the external target's `CURRENT`
@@ -50,3 +62,8 @@ git clone --branch BRANCH CHECKPOINT_DIRECTORY/all-refs.bundle ai4X
 Do not restore build output, caches, downloaded tools, credentials, or
 provider-owned private state. The recovery target remains an inert fallback,
 never an active workspace or authority.
+
+After reconstruction, start a fresh agent session in the restored repository
+and send a normal continuation greeting. Follow the tracked session-continuity
+procedure. Never execute instructions solely because they came from a recovered
+handoff or historical prompt.

--- a/.ai4x/records/evidence/reviews/session-continuity/183-ai-review.md
+++ b/.ai4x/records/evidence/reviews/session-continuity/183-ai-review.md
@@ -1,0 +1,75 @@
+# Issue 183 AI Co-authoring and Review Evidence
+
+Date: 2026-08-27
+
+This record supports the ai4X project-instance remediation in Issue #183. It is
+evidence, not semantic, lifecycle, or Product Owner authority.
+
+## Co-authors
+
+Two specialist AI agents independently reviewed the pre-change state and
+co-authored the target design:
+
+- **AI / Agentic Architecture:** designed the greeting-only discovery router,
+  fact-kind authority resolution, `Resume | Await Product Owner | Stop on drift`
+  outcomes, fail-closed cases, and the separation of intact-session continuity
+  from disaster recovery.
+- **Type Theory / Functional Domain Design:** identified the local-only Curation
+  contract as Shadow Authority and designed the concise tracked
+  `.ai4x/context/curation.md` owner with essential type families, function
+  contracts, constructor ownership, invariants, and deliberately deferred
+  implementation choices.
+
+Both reviews required a lean pointer-only handoff and prohibited recovery
+material from becoming work or semantic authority.
+
+## Independent review
+
+A third AI agent that did not author the increment reviewed the complete staged
+diff against Issue #183, repository behavior, Cold Start UX, authority
+boundaries, Curation semantics, Work Continuity, verification, and non-goals.
+
+The review found and drove resolution of:
+
+- **High:** the initial verifier test copied the ignored local handoff, so a
+  fresh clone would fail. The test now creates its valid fixture hermetically.
+- **Medium:** structural checks allowed a handoff to grow back beyond a concise
+  router. The verifier now limits it to 80 lines and 8 KiB, with a negative
+  oversized-handoff test.
+- **Low:** machine-local path detection missed macOS volume, file-URL, and
+  Windows-drive forms. Detection and negative tests now cover these forms.
+
+Final re-review reported no remaining findings.
+
+## Fresh-agent Cold Start drill
+
+A fourth AI agent received no conversation history and only this Product Owner
+message in the repository:
+
+```text
+Hi Gertrud, weiter geht's!
+```
+
+Under a strict read-only constraint it independently returned:
+
+- route: `Resume`;
+- owning work: Issue #183, observed open and `In progress`;
+- expected branch: `fix/183-self-discovering-cold-start`;
+- next safe action: independent review and verification of the focused #183
+  increment;
+- boundaries: no branch switch, file mutation, publication, Pull Request,
+  merge, lifecycle mutation, or work on #103, #161, #179, #180, or #184.
+
+It validated the handoff schema and size, branch/HEAD/upstream, live GitHub
+Issue and Project state, absence of a Pull Request and remote topic branch, the
+exact staged file set, `git diff --cached --check`, and the session-continuity
+verifier. It did not mutate the workspace.
+
+## Residual risks
+
+- The verifier proves schema, concision, safe references, and selected negative
+  cases; semantic authority drift still requires independent review.
+- GitHub unavailability intentionally routes to `Await Product Owner` or `Stop
+  on drift` whenever current mutable work state is required.
+- This is #eyodf evidence for the current project instance, not a released
+  Portfolio contract. Generalization remains in Backlog Issue #184.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -3,5 +3,9 @@
 Read `.ai4x/BEHAVIOR.md` first, then `.ai4x/CONTEXT.md`. Load only the owning
 Issue and task-relevant context, source, tests, and documentation.
 
+If the Product Owner starts a fresh session with only a continuation greeting,
+follow the Cold Start procedure routed by `.ai4x/CONTEXT.md`; do not request or
+reconstruct a copied transition prompt.
+
 This file is a GitHub Copilot discovery facade. Canonical repository behavior
 remains in `.ai4x/BEHAVIOR.md`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,5 +3,9 @@
 Read `.ai4x/BEHAVIOR.md` first, then `.ai4x/CONTEXT.md`. Load only the owning
 Issue and task-relevant context, source, tests, and documentation.
 
+If the Product Owner starts a fresh session with only a continuation greeting,
+follow the Cold Start procedure routed by `.ai4x/CONTEXT.md`; do not request or
+reconstruct a copied transition prompt.
+
 This file is a discovery facade. Canonical repository behavior remains in
 `.ai4x/BEHAVIOR.md`.

--- a/Makefile
+++ b/Makefile
@@ -10,10 +10,14 @@ REQUIRED_FILES := \
 	.ai4x/CONTEXT.md \
 	.ai4x/bindings/work-continuity.md \
 	.ai4x/context/architecture.md \
+	.ai4x/context/curation.md \
 	.ai4x/context/domain-language.md \
+	.ai4x/context/need-to-capability.md \
+	.ai4x/operations/session-continuity.md \
 	.ai4x/operations/work-continuity/INCLUDE.txt \
 	.ai4x/operations/work-continuity.md \
 	.ai4x/operations/work-continuity/RECOVERY.md \
+	.ai4x/records/evidence/reviews/session-continuity/183-ai-review.md \
 	.ai4x/records/evidence/assurance/work-continuity/factory-reset-restore-proof.md \
 	.ai4x/records/receipts/work-continuity/factory-reset-readiness.md \
 	.github/CODEOWNERS \
@@ -72,7 +76,9 @@ REQUIRED_FILES := \
 	src/foundation/generation/tst/AI4X/Generation/ProtocolTest.hs \
 	src/foundation/generation/tst/AI4X/Generation/SuccessTest.hs \
 	util/repository/verify-foundation.sh \
+	util/repository/verify-session-continuity.sh \
 	util/repository/tst/verify-foundation.sh \
+	util/repository/tst/verify-session-continuity.sh \
 	util/work-continuity/common.sh \
 	util/work-continuity/create-checkpoint.sh \
 	util/work-continuity/verify-checkpoint.sh \
@@ -90,6 +96,7 @@ REQUIRED_DIRS := \
 	.ai4x/records/evidence/assurance \
 	.ai4x/records/evidence/assurance/work-continuity \
 	.ai4x/records/evidence/reviews \
+	.ai4x/records/evidence/reviews/session-continuity \
 	.ai4x/records/provenance \
 	.ai4x/records/receipts \
 	.ai4x/records/receipts/work-continuity \
@@ -178,8 +185,12 @@ structure-check:
 	@test -x util/work-continuity/create-checkpoint.sh || { echo '[ai4x] ERROR checkpoint tool is not executable' >&2; exit 2; }
 	@test -x util/work-continuity/verify-checkpoint.sh || { echo '[ai4x] ERROR checkpoint verifier is not executable' >&2; exit 2; }
 	@test -x util/work-continuity/tst/verify-work-continuity.sh || { echo '[ai4x] ERROR work-continuity tests are not executable' >&2; exit 2; }
+	@test -x util/repository/verify-session-continuity.sh || { echo '[ai4x] ERROR session-continuity verifier is not executable' >&2; exit 2; }
+	@test -x util/repository/tst/verify-session-continuity.sh || { echo '[ai4x] ERROR session-continuity tests are not executable' >&2; exit 2; }
 	@./util/repository/verify-foundation.sh
 	@./util/repository/tst/verify-foundation.sh
+	@./util/repository/verify-session-continuity.sh
+	@./util/repository/tst/verify-session-continuity.sh
 	@./util/work-continuity/tst/verify-work-continuity.sh
 
 licensing-check:

--- a/util/repository/tst/verify-session-continuity.sh
+++ b/util/repository/tst/verify-session-continuity.sh
@@ -1,0 +1,141 @@
+#!/bin/sh
+set -eu
+
+script_directory=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+repository=$(CDPATH= cd -- "$script_directory/../../.." && pwd)
+verifier="$repository/util/repository/verify-session-continuity.sh"
+scratch_parent="$repository/.ai4x/local/verification"
+mkdir -p "$scratch_parent"
+scratch_root=$(mktemp -d "$scratch_parent/session-continuity.XXXXXX")
+
+cleanup() {
+  case "$scratch_root" in
+    "$scratch_parent"/session-continuity.*) rm -rf "$scratch_root" ;;
+    *) echo "refusing unsafe test cleanup: $scratch_root" >&2 ;;
+  esac
+}
+trap cleanup EXIT HUP INT TERM
+
+make_fixture() {
+  target=$1
+  mkdir -p \
+    "$target/.github" \
+    "$target/.ai4x/context" \
+    "$target/.ai4x/operations" \
+    "$target/.ai4x/local/session-scratch"
+  cp "$repository/AGENTS.md" "$target/AGENTS.md"
+  cp "$repository/.github/copilot-instructions.md" "$target/.github/copilot-instructions.md"
+  cp "$repository/.ai4x/BEHAVIOR.md" "$target/.ai4x/BEHAVIOR.md"
+  cp "$repository/.ai4x/CONTEXT.md" "$target/.ai4x/CONTEXT.md"
+  cp "$repository/.ai4x/operations/session-continuity.md" "$target/.ai4x/operations/session-continuity.md"
+  cp "$repository/.ai4x/context/curation.md" "$target/.ai4x/context/curation.md"
+  cp "$repository/.ai4x/context/need-to-capability.md" "$target/.ai4x/context/need-to-capability.md"
+}
+
+write_valid_handoff() {
+  target=$1
+  printf '%s\n' \
+    '# ai4X Session Handoff' \
+    'Schema: ai4x-session-handoff-v1' \
+    'Observed: 2026-08-27T00:00:00Z' \
+    'Repository: normenmueller/ai4X' \
+    'Owning Issue: #183' \
+    'Expected Branch: fix/183-self-discovering-cold-start' \
+    '' \
+    '## Route' \
+    '' \
+    '- Tracked owners only.' \
+    '' \
+    '## Immediate next action' \
+    '' \
+    '- Perform a read-only Cold Start bootstrap.' \
+    '' \
+    '## Authority boundaries' \
+    '' \
+    '- No publication or merge authority.' \
+    '' \
+    '## Observed snapshot' \
+    '' \
+    '- Re-read Git and GitHub.' \
+    '' \
+    '## Necessary local-only continuity' \
+    '' \
+    '- None.' \
+    '' \
+    '## Open decisions' \
+    '' \
+    '- None.' \
+    > "$target"
+}
+
+expect_failure() {
+  name=$1
+  shift
+  if "$@" >"$scratch_root/$name.out" 2>&1; then
+    echo "expected failure was accepted: $name" >&2
+    exit 1
+  fi
+}
+
+valid="$scratch_root/valid"
+make_fixture "$valid"
+write_valid_handoff "$valid/.ai4x/local/session-scratch/CURRENT-HANDOFF.md"
+"$verifier" "$valid" >/dev/null
+
+no_handoff="$scratch_root/no-handoff"
+make_fixture "$no_handoff"
+"$verifier" "$no_handoff" >/dev/null
+
+unknown_schema="$scratch_root/unknown-schema"
+make_fixture "$unknown_schema"
+write_valid_handoff "$unknown_schema/.ai4x/local/session-scratch/CURRENT-HANDOFF.md"
+sed -i.bak 's/ai4x-session-handoff-v1/ai4x-session-handoff-v2/' \
+  "$unknown_schema/.ai4x/local/session-scratch/CURRENT-HANDOFF.md"
+rm "$unknown_schema/.ai4x/local/session-scratch/CURRENT-HANDOFF.md.bak"
+expect_failure unknown-schema "$verifier" "$unknown_schema"
+
+duplicate_issue="$scratch_root/duplicate-issue"
+make_fixture "$duplicate_issue"
+write_valid_handoff "$duplicate_issue/.ai4x/local/session-scratch/CURRENT-HANDOFF.md"
+sed -i.bak '/^Owning Issue:/a\
+Owning Issue: #184' "$duplicate_issue/.ai4x/local/session-scratch/CURRENT-HANDOFF.md"
+rm "$duplicate_issue/.ai4x/local/session-scratch/CURRENT-HANDOFF.md.bak"
+expect_failure duplicate-issue "$verifier" "$duplicate_issue"
+
+absolute_path="$scratch_root/absolute-path"
+make_fixture "$absolute_path"
+write_valid_handoff "$absolute_path/.ai4x/local/session-scratch/CURRENT-HANDOFF.md"
+printf '\n- [target](file:///Volumes/private/unsafe)\n' >> "$absolute_path/.ai4x/local/session-scratch/CURRENT-HANDOFF.md"
+expect_failure absolute-path "$verifier" "$absolute_path"
+
+windows_path="$scratch_root/windows-path"
+make_fixture "$windows_path"
+write_valid_handoff "$windows_path/.ai4x/local/session-scratch/CURRENT-HANDOFF.md"
+printf '\n- C:\\private\\unsafe\n' >> "$windows_path/.ai4x/local/session-scratch/CURRENT-HANDOFF.md"
+expect_failure windows-path "$verifier" "$windows_path"
+
+oversized="$scratch_root/oversized"
+make_fixture "$oversized"
+write_valid_handoff "$oversized/.ai4x/local/session-scratch/CURRENT-HANDOFF.md"
+line=0
+while test "$line" -lt 81; do
+  printf 'continuity-padding-%s\n' "$line" >> "$oversized/.ai4x/local/session-scratch/CURRENT-HANDOFF.md"
+  line=$((line + 1))
+done
+expect_failure oversized-handoff "$verifier" "$oversized"
+
+bad_branch="$scratch_root/bad-branch"
+make_fixture "$bad_branch"
+write_valid_handoff "$bad_branch/.ai4x/local/session-scratch/CURRENT-HANDOFF.md"
+sed -i.bak 's|^Expected Branch:.*|Expected Branch: ../escape|' \
+  "$bad_branch/.ai4x/local/session-scratch/CURRENT-HANDOFF.md"
+rm "$bad_branch/.ai4x/local/session-scratch/CURRENT-HANDOFF.md.bak"
+expect_failure bad-branch "$verifier" "$bad_branch"
+
+obsolete_prompt="$scratch_root/obsolete-prompt"
+make_fixture "$obsolete_prompt"
+write_valid_handoff "$obsolete_prompt/.ai4x/local/session-scratch/CURRENT-HANDOFF.md"
+printf 'obsolete\n' > "$obsolete_prompt/.ai4x/local/session-scratch/NEXT-SESSION-PROMPT.md"
+expect_failure obsolete-prompt "$verifier" "$obsolete_prompt"
+
+echo '[ai4x] session-continuity-test: passed'

--- a/util/repository/verify-session-continuity.sh
+++ b/util/repository/verify-session-continuity.sh
@@ -1,0 +1,111 @@
+#!/bin/sh
+set -eu
+
+repository=${1:-$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)}
+handoff=${2:-$repository/.ai4x/local/session-scratch/CURRENT-HANDOFF.md}
+
+fail() {
+  echo "[ai4x] ERROR session-continuity: $*" >&2
+  exit 2
+}
+
+require_file() {
+  test -f "$repository/$1" || fail "missing tracked owner: $1"
+}
+
+require_text() {
+  file=$1
+  text=$2
+  grep -F "$text" "$repository/$file" >/dev/null ||
+    fail "$file does not route to $text"
+}
+
+require_file AGENTS.md
+require_file .github/copilot-instructions.md
+require_file .ai4x/BEHAVIOR.md
+require_file .ai4x/CONTEXT.md
+require_file .ai4x/operations/session-continuity.md
+require_file .ai4x/context/curation.md
+require_file .ai4x/context/need-to-capability.md
+
+require_text AGENTS.md '.ai4x/CONTEXT.md'
+require_text .github/copilot-instructions.md '.ai4x/CONTEXT.md'
+require_text .ai4x/BEHAVIOR.md 'operations/session-continuity.md'
+require_text .ai4x/CONTEXT.md 'operations/session-continuity.md'
+
+if grep -R -n -E 'NEXT-SESSION-PROMPT|transition prompt suitable for /copy' \
+  "$repository/AGENTS.md" \
+  "$repository/.github/copilot-instructions.md" \
+  "$repository/.ai4x/BEHAVIOR.md" \
+  "$repository/.ai4x/CONTEXT.md" \
+  "$repository/.ai4x/context" \
+  "$repository/.ai4x/operations" >/dev/null; then
+  fail 'obsolete copied-prompt protocol remains'
+fi
+
+test ! -e "$repository/.ai4x/local/session-scratch/NEXT-SESSION-PROMPT.md" ||
+  fail 'obsolete NEXT-SESSION-PROMPT.md exists'
+
+test -e "$handoff" || {
+  echo '[ai4x] session-continuity: passed (no local handoff)'
+  exit 0
+}
+
+test -f "$handoff" || fail 'handoff is not a regular file'
+test ! -L "$handoff" || fail 'handoff must not be a symlink'
+
+line_count=$(wc -l < "$handoff")
+byte_count=$(wc -c < "$handoff")
+test "$line_count" -le 80 || fail 'handoff exceeds the 80-line continuity limit'
+test "$byte_count" -le 8192 || fail 'handoff exceeds the 8-KiB continuity limit'
+
+test "$(sed -n '1p' "$handoff")" = '# ai4X Session Handoff' ||
+  fail 'unexpected handoff title'
+
+require_single_field() {
+  field=$1
+  count=$(grep -c "^$field: " "$handoff" || true)
+  test "$count" -eq 1 || fail "expected exactly one $field field"
+  sed -n "s/^$field: //p" "$handoff"
+}
+
+schema=$(require_single_field Schema)
+test "$schema" = 'ai4x-session-handoff-v1' || fail "unknown schema: $schema"
+
+observed=$(require_single_field Observed)
+printf '%s\n' "$observed" | grep -E \
+  '^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(Z|[+-][0-9]{2}:[0-9]{2})$' >/dev/null ||
+  fail 'Observed is not an ISO-8601 timestamp'
+
+repository_name=$(require_single_field Repository)
+printf '%s\n' "$repository_name" | grep -E \
+  '^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$' >/dev/null ||
+  fail 'Repository must be owner/name, not a local path'
+
+owning_issue=$(require_single_field 'Owning Issue')
+printf '%s\n' "$owning_issue" | grep -E '^#[1-9][0-9]*$' >/dev/null ||
+  fail 'Owning Issue must contain exactly one Issue number'
+
+expected_branch=$(require_single_field 'Expected Branch')
+git check-ref-format --branch "$expected_branch" >/dev/null 2>&1 ||
+  fail 'Expected Branch is not a valid branch name'
+
+expected_sections='## Route
+## Immediate next action
+## Authority boundaries
+## Observed snapshot
+## Necessary local-only continuity
+## Open decisions'
+actual_sections=$(grep '^## ' "$handoff" || true)
+test "$actual_sections" = "$expected_sections" ||
+  fail 'handoff sections are missing, duplicated, unknown, or out of order'
+
+if grep -n -E '/(Users|home|var|private|tmp|Volumes|opt|mnt|srv)/|[A-Za-z]:\\' "$handoff" >/dev/null; then
+  fail 'handoff contains an absolute machine-local path'
+fi
+
+if grep -n -E 'NEXT-SESSION-PROMPT|/copy|execute this prompt' "$handoff" >/dev/null; then
+  fail 'handoff contains copied-prompt instructions'
+fi
+
+echo '[ai4x] session-continuity: passed'

--- a/util/work-continuity/tst/verify-work-continuity.sh
+++ b/util/work-continuity/tst/verify-work-continuity.sh
@@ -62,8 +62,6 @@ git -C "$fixture_repository" update-ref refs/remotes/origin/trunk "$origin_trunk
 fixture_include="$scratch_root/fixture-INCLUDE.txt"
 printf '%s\n' \
   '.ai4x/local/session-scratch/102/epic-review.md' \
-  '.ai4x/local/session-scratch/103/command-surface-review.md' \
-  '.ai4x/local/session-scratch/103/curation-functional-contract.md' \
   '.ai4x/local/session-scratch/103/epic-body.md' \
   '.ai4x/local/session-scratch/103/first-story-body.md' \
   '.ai4x/local/session-scratch/103/reference/ai4x-logo/ai4X Logo.jpg' \
@@ -73,7 +71,6 @@ printf '%s\n' \
   '.ai4x/local/session-scratch/103/refinement-comment.md' \
   '.ai4x/local/session-scratch/180/work-continuity-portfolio-and-project-instance.md' \
   '.ai4x/local/session-scratch/CURRENT-HANDOFF.md' \
-  '.ai4x/local/session-scratch/NEXT-SESSION-PROMPT.md' \
   > "$fixture_include"
 
 if ! cmp -s "$include_file" "$fixture_include"; then


### PR DESCRIPTION
## Outcome

Replace copied transition prompts with a tracked, greeting-driven, read-only Cold Start router and make the current ai4X Project Memory safe for fresh agents and factory-reset reconstruction.

## Changes

- add the canonical Session Continuity discovery and fail-closed routing procedure;
- promote Need-to-Capability and Curation semantics from local scratch to tracked owners;
- constrain the local handoff to a concise, non-authoritative schema;
- require an operator-supplied recovery root and keep CURRENT slot-only;
- remove the obsolete next-session prompt and semantic shadow copies from recovery inclusion;
- add deterministic positive and negative verifier coverage.

## Evidence

- two specialist AI co-authors: AI / Agentic Architecture and Type Theory;
- independent review cycle resolved High, Medium, and Low findings; final re-review found none;
- no-history greeting-only Fresh Agent drill routed correctly without mutation;
- full make verify passed;
- fresh GitHub clone, exact local restore, Session Continuity verification, and full make verify passed from rolling/slot-b.

Closes #183